### PR TITLE
Add Python interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ And here's the same thing in idiomatic Rockstar, using poetic literals and no in
 
 ```
 Midnight takes your heart and your soul
-While your heart is higher than your soul
+While your heart is higher than your soul or your heart is your soul
 Take your soul from your heart
 Give back your heart
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ A poetic number literal begins with a variable name, followed by one of the keyw
 
 * `Tommy was a lovestruck ladykiller` initialises `Tommy` with the value `100`
 * `Sweet Lucy was a dancer` - initialises `Sweet Lucy` with the value 16
-* `My dreams were ice. A life unfulfilled; wakin' everybody up, taking booze and pills` - initialises `my dreams` with the value `3.1415926535'
+* `My dreams were ice. A life unfulfilled; wakin' everybody up, taking booze and pills` - initialises `my dreams` with the value `3.1415926535`
+ * Note that poetic literals **can** include reserved keywords, as with `taking` in this example.
 
 ### Comparison
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Rockstar uses a very similar type system to that defined by the [ECMAScript type
 * **Mysterious** - the value of any variable that hasn't been assigned a value, denoted by the keyword `mysterious`
 * **Null** - the null type. Evaluates as equal to zero and equal to false. The keywords `nothing`, `nowhere` and `nobody` are defined as aliases for `null`
 * **Boolean** - a logical entity having two values `true` and `false`. *(The keywords `maybe` and `definitely maybe` are reserved for future use)*
+ * `right`, `yes` and `ok` are valid aliases for `true`
+ * `wrong`, `no` and `lies` are valid aliases for `false`
 * **Number** - Numbers in Rockstar are stored using the [DEC64](http://www.dec64.com/) numeric type.
 * **String** - Rockstar strings are sequences of 16-bit unsigned integer values representing UTF-16 code units.
 * **Object** - a collection of named data properties, as in ECMAScript.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Similar to the single-equals operator in Visual Basic and some scripting languag
 Comparison in Rockstar can only be done within an expression.
 
 * `Tommy is nobody` initialises the variable `Tommy` with the value `nobody`
-* `If Tommy is nobody then` - will execute the next line if, and only if, the variable `Tommy` is equal to `nobody`
+* `If Tommy is nobody` - will execute the following block if, and only if, the variable `Tommy` is equal to `nobody`
 
 The modifier `not`  will invert the meaning of the comparison, similar to `IS NULL / IS NOT NULL` in SQL. The keyword `ain't` is an alias for `is not`. This usage runs contrary to idiomatic English, where "Tommy isn't anybody", "Tommy ain't nobody" and "Tommy ain't not nobody" somehow mean exactly the same thing.
 
@@ -137,24 +137,23 @@ Similar to the `If` statement, a loop is denoted by the `While` or `Until` keywo
 Tommy was a dancer
 While Tommy ain't nothing,
 Knock Tommy down
-And around we go
 ```
 
 That'll initialize Tommy with the value 16 (using the poetic number literal syntax) and then loop, decrementing Tommy by 1 each time until Tommy equals zero (i.e `ain't nothing` returns false).
 
 
-The `break` and `continue` statements work as they do in most block-based languages. Rockstar defines `Break it down!` as an alias for `break` and `Take it to the top` as an alias for `continue` 
+The `break` and `continue` statements work as they do in most block-based languages. Rockstar defines `Break it down` as an alias for `break` and `Take it to the top` as an alias for `continue` 
 
 #### Blocks
 
-A block of statements in Rockstar is denoted by the `and` keyword at the start of a line. Any line beginning with `and` forms part of a block statement continuing the previous line. The block ends when we hit a statement that doesn't start with `and`
+A block in Rockstar starts with an `If`, `Else`, `While` or `Until` statement, and is terminated by a blank line or the end-of-file. EOF ends all open code blocks
 
 ```
 Tommy was a dancer
 While Tommy ain't nothing
 Shout it
 Knock it down
-And around we go
+
 ```
 
 ### Functions
@@ -180,24 +179,28 @@ Modulus takes Number and Divisor
 While Number is higher than Divisor
 Take Divisor from Number
 Give back Number
-
+    (blank line ending While block)
+    (blank line ending function declaration)
 Limit is 100
 Counter is 0
 Fizz is 3
 Buzz is 5
 Until Counter is Limit
-	Build Counter up
-	If Modulus taking Counter, Fizz is 0 and Modulus taking Counter, Buzz is 0
-		Say "FizzBuzz!"
-		And Continue
-	If Modulus taking Counter and Fizz is 0
-		Say "Fizz!"
-		And Continue
-	If Modulus taking Counter and Buzz is 0
-		Say "Buzz!"
-		And Continue
-	Say Counter
-End
+Build Counter up
+If Modulus taking Counter, Fizz is 0 and Modulus taking Counter, Buzz is 0
+Say "FizzBuzz!"
+Continue
+    (blank line ending 'If' Block)
+If Modulus taking Counter and Fizz is 0
+Say "Fizz!"
+Continue
+    (blank line ending 'If' Block)	
+If Modulus taking Counter and Buzz is 0
+Say "Buzz!"
+Continue
+    (blank line ending 'If' Block)
+Say Counter
+    (blank line ending Until block)
 ```
 
 And here's the same thing in idiomatic Rockstar, using poetic literals and no indentation
@@ -208,23 +211,26 @@ While your heart is higher than your soul or your heart is your soul
 Take your soul from your heart
 Give back your heart
 
+
 Desire is a lovestruck ladykiller
 My world is nothing 
 Fire is ice
 Hate is water
 Until my world is Desire,
 Build my world up
-If Midnight taking Desire, Fire is nothing and Midnight taking Desire, Hate is nothing
+If Midnight taking my world, Fire is nothing and Midnight taking my world, Hate is nothing
 Shout "FizzBuzz!"
-And take it to the top
-If Midnight taking Desire, Fire is nothing
+Take it to the top
+
+If Midnight taking my world, Fire is nothing
 Shout "Fizz!"
-And take it to the top
-If Midnight taking Desire, Hate is nothing
+Take it to the top
+
+If Midnight taking my world, Hate is nothing
 Say "Buzz!"
-And take it to the top
+Take it to the top
+
 Whisper my world
-And around we go
 ```
 
 ## Ideas

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rockstar is intended to give the programmer an unprecedented degree of poetic li
 
 There's two ways to declare and use variables in Rockstar. 
 
-**Common variables** consist of one of the keywords `the`, `my` or `your` followed by a unique variable name, which must contain only lowercase ASCII letters a-z. 
+**Common variables** consist of one of the keywords `a`, `an`, `the`, `my` or `your` followed by a unique variable name, which must contain only lowercase ASCII letters a-z. 
 
 **Proper variables** are proper nouns - any word that isn't a reserved keyword and starts with an uppercase letter. Proper variable names can contain spaces as long as each space is followed by an uppercase letter. Whilst some developers may use this feature to create variables with names like `Customer ID`, `Tax Rate` or `Distance In KM`, we recommend you favour idiomatic variable names such as `Tommy`, `Gina`, `Doctor Feelgood`, `Mister Crowley`, `Kayleigh`, `Tom Sawyer`, `Billie Jean` and `Janie`. 
 
@@ -94,6 +94,7 @@ A poetic number literal begins with a variable name, followed by one of the keyw
 
 * `Tommy was a lovestruck ladykiller` initialises `Tommy` with the value `100`
 * `Sweet Lucy was a dancer` - initialises `Sweet Lucy` with the value 16
+* `A killer is on the loose` - initialises `a killer` with the value 235.
 * `My dreams were ice. A life unfulfilled; wakin' everybody up, taking booze and pills` - initialises `my dreams` with the value `3.1415926535`
  * Note that poetic literals **can** include reserved keywords, as with `taking` in this example.
 

--- a/rockstar.py
+++ b/rockstar.py
@@ -298,5 +298,10 @@ Until Counter is Limit
 End
 """
 
-    expected = ['Fizz' * (i%3==0) + 'Buzz' * (i%5==0) or str(i) for i in range(1, 101)]
-    run(fizzbuzz1)
+    import sys
+    if len(sys.argv) > 1:
+        with open(sys.argv[1]) as f:
+            run(f.read())
+    else:
+        expected = ['Fizz' * (i%3==0) + 'Buzz' * (i%5==0) or str(i) for i in range(1, 101)]
+        run(fizzbuzz1)


### PR DESCRIPTION
I've created a Python 3.6 implementation complete enough to run both FizzBuzz examples. There were mistakes in the examples (and the specs) that had to be fixed, though.

I liked the idea of the language, and I had fun implementing an interpreter. The code is terrible, but I think it's in spirit of the joke ;)

Main problems I found and fixed:

- Examples are using `greater than` when it should be `>=`.
- `Midnight taking Desire, Fire` should be `Midnight taking my world, Fire`.
- Loops are inconsistently defined. The `Until Counter is Limit` should only include the very next line, because the rest doesn't start with `and`. The way I implemented you, if the second line doesn't start with `and`, then the loop blocks goes until EOF, `And around we go` or `End`. Not intuitive, but requires the least changes in the examples/spec.
- If you use `Midnight taking Desire and Fire` instead of `Midnight taking Desire, Fire` in a conditional, the grammar becomes ambiguous (is that "and" separating the parameters or a boolean OR?).
- Probably more that I forgot.