### PR TITLE
Add parsing for 'listen' and 'listen to' statements.

### DIFF
--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -151,7 +151,7 @@ class TokenType(Enum):
     ReservedContinue = auto()        # `continue` or `take it to the top`
     ReservedPut = auto()             # `put Val into Val2` (put)
     ReservedInto = auto()            # `put Val into Val2` (into)
-    ReservedListen = auto()          # `listen to Val` (listen)
+    ReservedListen = auto()          # `listen` (listen)
     ReservedListenTo = auto()        # `listen to Val` (listen to)
     ReservedSay = auto()             # `say/shout/whisper/scream Val` (say)
     ReservedReturn = auto()          # `give back Val` (give back)
@@ -300,7 +300,7 @@ class ASTType(Enum):
     Decrement = auto()           # children: [variable]
 
     Print = auto()               # children: [value]
-    GetLine = auto()             # children: [variable]
+    GetLine = auto()             # children: [variable] or []
     Set = auto()                 # children: [variable, value]
 
     IfStatement = auto()         # children: [condition, statements...]

--- a/src/parser.py
+++ b/src/parser.py
@@ -56,6 +56,8 @@ class RockstarParser:
             return self.put_statement()
         if self.__token_consumer.is_next(TokenType.ReservedListen):
             return self.listen_statement()
+        if self.__token_consumer.is_next(TokenType.ReservedListenTo):
+            return self.listen_to_statement()
         if self.__token_consumer.is_next(TokenType.ReservedSay):
             return self.say_statement()
         if self.__token_consumer.is_next(TokenType.ReservedReturn):
@@ -93,6 +95,28 @@ class RockstarParser:
 
         surrounding_location: SourceLocation = put_token.location.extend(variable.location)
         return ASTNode(ASTType.Set, None, location=surrounding_location, children=[variable, expr])
+
+    def listen_statement(self) -> ASTNode:
+        """
+        "listen"
+        """
+        listen_token: Optional[Token] = self.__token_consumer.get_next(TokenType.ReservedListen)
+        if listen_token is None:
+            raise self.make_missing_token_error(TokenType.ReservedListen)
+        return ASTNode(ASTType.GetLine, None, location=listen_token.location, children=[])
+
+    def listen_to_statement(self) -> ASTNode:
+        """
+        "listen to" <variable>
+        """
+        listen_to_token: Optional[Token] = self.__token_consumer.get_next(TokenType.ReservedListenTo)
+        if listen_to_token is None:
+            raise self.make_missing_token_error(TokenType.ReservedListenTo)
+
+        variable: ASTNode = self.variable()
+
+        surrounding_location = listen_to_token.location.extend(variable.location)
+        return ASTNode(ASTType.GetLine, None, location=surrounding_location, children=[variable])
 
 def parse(tokens: TokenStream) -> ASTNode:
     """


### PR DESCRIPTION
First pass on parsing for "listen" and "listen to" statements. Currently, each is a separate function. They could be combined into a single function but I prefer keeping them separate since there's very little overlap between the two.