### PR TITLE
Remove eof workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+      - run: yarn pegjs
       - run: yarn test
   deploy:
     docker:

--- a/satriani/README.md
+++ b/satriani/README.md
@@ -95,8 +95,7 @@ AST is a JSON object representing your program as a tree of operations.
 **[rockstar.interpreter.js](satriani.interpreter.js)** is a runtime interpreter that can take the AST created by the parser and evaluate it. It's pluggable
 so you can override the I/O mechanisms.
 
-The test suite is runnable using [Mocha](https://mochajs.org/) - each 'test' is defined as a .rock source file and an .rock.out output file. so the 
-test suite is completely platform-agnostic.
+The test suite is runnable using [Mocha](https://mochajs.org/) - each 'test' is defined as a .rock source file and an .rock.out output file, so the test suite is completely platform-agnostic.
 
 ## Acknowledgements
 

--- a/satriani/README.md
+++ b/satriani/README.md
@@ -76,6 +76,12 @@ grammar is defined in **[rockstar.peg](rockstar.peg)**.
 We use the `pegjs` command line to generate `rockstar.parser.js`, which is the parser itself:
 
 ```
+$ pegjs -o rockstar.parser.js rockstar.peg
+```
+
+This is also defined as a yarn build task, so you can build the parser using:
+
+```
 $ yarn run pegjs
 ```
 

--- a/satriani/README.md
+++ b/satriani/README.md
@@ -76,7 +76,7 @@ grammar is defined in **[rockstar.peg](rockstar.peg)**.
 We use the `pegjs` command line to generate `rockstar.parser.js`, which is the parser itself:
 
 ```
-$ pegjs -o rockstar.parser.js rockstar.peg
+$ yarn run pegjs
 ```
 
 **[rockstar.parser.js](rockstar.parser.js)** exports a function `parse(input, options)`, where `input` 

--- a/satriani/package.json
+++ b/satriani/package.json
@@ -20,7 +20,8 @@
     "browserify": "node node_modules/browserify/bin/cmd.js satriani.js --standalone Satriani -o deploy/docs/js/satriani.js",
     "deploy": "node_modules/gh-pages/bin/gh-pages.js -u 'CircleCI <circleci@codewithrockstar.com>' -r git@github.com:RockstarLang/codewithrockstar.com.git --add --src docs/js/satriani.js -m 'Updated js/satriani.js from main repo' -b master -d deploy",
     "serve": "python -m SimpleHTTPServer 8000",
-    "test": "pegjs -o satriani.parser.js rockstar.peg; mocha test/*.js"
+    "pegjs": "node node_modules/pegjs/bin/pegjs -o satriani.parser.js rockstar.peg",
+    "test": "mocha test/*.js"
   },
   "repository": {
     "type": "git",

--- a/satriani/rockstar.peg
+++ b/satriani/rockstar.peg
@@ -6,7 +6,7 @@ After updating, run pegjs -o rockstar-parser.js rockstar.peg
 
 program     = p:line * { return { list: p.filter(item => item) } }
 
-line = _* s:statement EOL+ { return s }
+line = _* s:statement (EOL+ / EOF) { return s }
   /
     EOL { return null }
 
@@ -16,6 +16,7 @@ _           = (whitespace / comment)+
 
 noise 	= (_ / [;,?!&.])
 EOL = 	noise* '\n'
+EOF = !.
 
 ignore_rest_of_line = (_[^\n]*)?
 

--- a/satriani/satriani.js
+++ b/satriani/satriani.js
@@ -12,13 +12,7 @@ module.exports = {
         }
 
         this.parse = function(program) {
-            // In Rockstar, the end-of-file (EOF) implicitly closes any open blocks and loops
-            // This is surprisingly difficult to implement in a parsing expression
-            // grammar - probably because EOF isn't something the parser can 'consume'
-            // So... we stick a load of extra newlines onto the program before we pass
-            // it to the parser. It's hacky as all hell - and won't work if you're >8 blocks
-            // deep when we reach the EOF - but it works. :)
-            return parser.parse(program + "\n\n\n\n\n\n\n\n");
+            return parser.parse(program);
         }
     }
 };

--- a/satriani/satriani.parser.js
+++ b/satriani/satriani.parser.js
@@ -156,62 +156,63 @@ function peg$parse(input, options) {
       peg$c12 = peg$classExpectation([";", ",", "?", "!", "&", "."], false, false),
       peg$c13 = "\n",
       peg$c14 = peg$literalExpectation("\n", false),
-      peg$c15 = /^[^\n]/,
-      peg$c16 = peg$classExpectation(["\n"], true, false),
-      peg$c17 = "break",
-      peg$c18 = peg$literalExpectation("break", true),
-      peg$c19 = function() {
+      peg$c15 = peg$anyExpectation(),
+      peg$c16 = /^[^\n]/,
+      peg$c17 = peg$classExpectation(["\n"], true, false),
+      peg$c18 = "break",
+      peg$c19 = peg$literalExpectation("break", true),
+      peg$c20 = function() {
       	return { 'break' : {} }
       },
-      peg$c20 = "continue",
-      peg$c21 = peg$literalExpectation("continue", true),
-      peg$c22 = "take it to the top",
-      peg$c23 = peg$literalExpectation("take it to the top", true),
-      peg$c24 = function() {
+      peg$c21 = "continue",
+      peg$c22 = peg$literalExpectation("continue", true),
+      peg$c23 = "take it to the top",
+      peg$c24 = peg$literalExpectation("take it to the top", true),
+      peg$c25 = function() {
       	return { 'continue' : {} }
       },
-      peg$c25 = "takes",
-      peg$c26 = peg$literalExpectation("takes", true),
-      peg$c27 = function(name, args, body) { return { 'function': {
+      peg$c26 = "takes",
+      peg$c27 = peg$literalExpectation("takes", true),
+      peg$c28 = function(name, args, body) { return { 'function': {
           	name: name,
               args: args.map(arg => arg),
               body: body
           } } },
-      peg$c28 = ", and",
-      peg$c29 = peg$literalExpectation(", and", false),
-      peg$c30 = "and",
-      peg$c31 = peg$literalExpectation("and", false),
-      peg$c32 = "&",
-      peg$c33 = peg$literalExpectation("&", false),
-      peg$c34 = ",",
-      peg$c35 = peg$literalExpectation(",", false),
-      peg$c36 = "'n'",
-      peg$c37 = peg$literalExpectation("'n'", false),
-      peg$c38 = function(head, tail) { return [head].concat(tail) },
-      peg$c39 = function(arg) { return [arg] },
-      peg$c40 = "taking",
-      peg$c41 = peg$literalExpectation("taking", true),
-      peg$c42 = function(name, args) { return { 'call': { name: name, args: args } } },
-      peg$c43 = "return",
-      peg$c44 = peg$literalExpectation("return", true),
-      peg$c45 = "give back",
-      peg$c46 = peg$literalExpectation("give back", true),
-      peg$c47 = function(e) { return { 'return': { 'expression' : e } } },
-      peg$c48 = "listen to",
-      peg$c49 = peg$literalExpectation("listen to", true),
-      peg$c50 = function(v) { return { 'assign': { 'expression': { 'listen' : ''}, 'variable': v } } },
-      peg$c51 = "listen",
-      peg$c52 = peg$literalExpectation("listen", true),
-      peg$c53 = function() { return { 'listen' : ''} },
-      peg$c54 = function(head, tail) {
+      peg$c29 = ", and",
+      peg$c30 = peg$literalExpectation(", and", false),
+      peg$c31 = "and",
+      peg$c32 = peg$literalExpectation("and", false),
+      peg$c33 = "&",
+      peg$c34 = peg$literalExpectation("&", false),
+      peg$c35 = ",",
+      peg$c36 = peg$literalExpectation(",", false),
+      peg$c37 = "'n'",
+      peg$c38 = peg$literalExpectation("'n'", false),
+      peg$c39 = function(head, tail) { return [head].concat(tail) },
+      peg$c40 = function(arg) { return [arg] },
+      peg$c41 = "taking",
+      peg$c42 = peg$literalExpectation("taking", true),
+      peg$c43 = function(name, args) { return { 'call': { name: name, args: args } } },
+      peg$c44 = "return",
+      peg$c45 = peg$literalExpectation("return", true),
+      peg$c46 = "give back",
+      peg$c47 = peg$literalExpectation("give back", true),
+      peg$c48 = function(e) { return { 'return': { 'expression' : e } } },
+      peg$c49 = "listen to",
+      peg$c50 = peg$literalExpectation("listen to", true),
+      peg$c51 = function(v) { return { 'assign': { 'expression': { 'listen' : ''}, 'variable': v } } },
+      peg$c52 = "listen",
+      peg$c53 = peg$literalExpectation("listen", true),
+      peg$c54 = function() { return { 'listen' : ''} },
+      peg$c55 = function(head, tail) {
                 return { list : [head].concat(tail) }
               },
-      peg$c55 = "else",
-      peg$c56 = peg$literalExpectation("else", true),
-      peg$c57 = function(a) { return a },
-      peg$c58 = "if",
-      peg$c59 = peg$literalExpectation("if", true),
-      peg$c60 = function(e, c, a) {
+      peg$c56 = "else",
+      peg$c57 = peg$literalExpectation("else", true),
+      peg$c58 = function(a) { return a },
+      peg$c59 = "if",
+      peg$c60 = peg$literalExpectation("if", true),
+      peg$c61 = function(e, c, a) {
                 return {
                     'conditional': {
                         'condition' : e,
@@ -220,101 +221,101 @@ function peg$parse(input, options) {
                       }
                   };
               },
-      peg$c61 = "while",
-      peg$c62 = peg$literalExpectation("while", true),
-      peg$c63 = function(e, c) { return { 'while_loop': {
+      peg$c62 = "while",
+      peg$c63 = peg$literalExpectation("while", true),
+      peg$c64 = function(e, c) { return { 'while_loop': {
                   'condition': e,
                   'consequent': c
                } }; },
-      peg$c64 = "until",
-      peg$c65 = peg$literalExpectation("until", true),
-      peg$c66 = function(e, c) { return { 'until_loop': {
+      peg$c65 = "until",
+      peg$c66 = peg$literalExpectation("until", true),
+      peg$c67 = function(e, c) { return { 'until_loop': {
                   'condition': e,
                   'consequent': c
                } }; },
-      peg$c67 = "say",
-      peg$c68 = peg$literalExpectation("say", true),
-      peg$c69 = "shout",
-      peg$c70 = peg$literalExpectation("shout", true),
-      peg$c71 = "whisper",
-      peg$c72 = peg$literalExpectation("whisper", true),
-      peg$c73 = "scream",
-      peg$c74 = peg$literalExpectation("scream", true),
-      peg$c75 = function(e) {return {'output': e}},
-      peg$c76 = "true",
-      peg$c77 = peg$literalExpectation("true", true),
-      peg$c78 = "ok",
-      peg$c79 = peg$literalExpectation("ok", true),
-      peg$c80 = "right",
-      peg$c81 = peg$literalExpectation("right", true),
-      peg$c82 = "yes",
-      peg$c83 = peg$literalExpectation("yes", true),
-      peg$c84 = function() { return { constant: true } },
-      peg$c85 = "false",
-      peg$c86 = peg$literalExpectation("false", true),
-      peg$c87 = "lies",
-      peg$c88 = peg$literalExpectation("lies", true),
-      peg$c89 = "wrong",
-      peg$c90 = peg$literalExpectation("wrong", true),
-      peg$c91 = "no",
-      peg$c92 = peg$literalExpectation("no", true),
-      peg$c93 = function() { return { constant: false } },
-      peg$c94 = "null",
-      peg$c95 = peg$literalExpectation("null", true),
-      peg$c96 = "nothing",
-      peg$c97 = peg$literalExpectation("nothing", true),
-      peg$c98 = "nowhere",
-      peg$c99 = peg$literalExpectation("nowhere", true),
-      peg$c100 = "nobody",
-      peg$c101 = peg$literalExpectation("nobody", true),
-      peg$c102 = "empty",
-      peg$c103 = peg$literalExpectation("empty", true),
-      peg$c104 = "gone",
-      peg$c105 = peg$literalExpectation("gone", true),
-      peg$c106 = function() { return { constant: null } },
-      peg$c107 = "mysterious",
-      peg$c108 = peg$literalExpectation("mysterious", false),
-      peg$c109 = function() { return '__MYSTERIOUS__' },
-      peg$c110 = "-",
-      peg$c111 = peg$literalExpectation("-", false),
-      peg$c112 = /^[0-9]/,
-      peg$c113 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c114 = ".",
-      peg$c115 = peg$literalExpectation(".", false),
-      peg$c116 = function(n) { return {number: parseFloat(n)} },
-      peg$c117 = function(n) { return {number: parseFloat(n) } },
-      peg$c118 = "\"",
-      peg$c119 = peg$literalExpectation("\"", false),
-      peg$c120 = /^[^"]/,
-      peg$c121 = peg$classExpectation(["\""], true, false),
-      peg$c122 = function(s) { return {string: s}},
-      peg$c123 = "nor",
-      peg$c124 = peg$literalExpectation("nor", false),
-      peg$c125 = function(lhs, rhs) {
+      peg$c68 = "say",
+      peg$c69 = peg$literalExpectation("say", true),
+      peg$c70 = "shout",
+      peg$c71 = peg$literalExpectation("shout", true),
+      peg$c72 = "whisper",
+      peg$c73 = peg$literalExpectation("whisper", true),
+      peg$c74 = "scream",
+      peg$c75 = peg$literalExpectation("scream", true),
+      peg$c76 = function(e) {return {'output': e}},
+      peg$c77 = "true",
+      peg$c78 = peg$literalExpectation("true", true),
+      peg$c79 = "ok",
+      peg$c80 = peg$literalExpectation("ok", true),
+      peg$c81 = "right",
+      peg$c82 = peg$literalExpectation("right", true),
+      peg$c83 = "yes",
+      peg$c84 = peg$literalExpectation("yes", true),
+      peg$c85 = function() { return { constant: true } },
+      peg$c86 = "false",
+      peg$c87 = peg$literalExpectation("false", true),
+      peg$c88 = "lies",
+      peg$c89 = peg$literalExpectation("lies", true),
+      peg$c90 = "wrong",
+      peg$c91 = peg$literalExpectation("wrong", true),
+      peg$c92 = "no",
+      peg$c93 = peg$literalExpectation("no", true),
+      peg$c94 = function() { return { constant: false } },
+      peg$c95 = "null",
+      peg$c96 = peg$literalExpectation("null", true),
+      peg$c97 = "nothing",
+      peg$c98 = peg$literalExpectation("nothing", true),
+      peg$c99 = "nowhere",
+      peg$c100 = peg$literalExpectation("nowhere", true),
+      peg$c101 = "nobody",
+      peg$c102 = peg$literalExpectation("nobody", true),
+      peg$c103 = "empty",
+      peg$c104 = peg$literalExpectation("empty", true),
+      peg$c105 = "gone",
+      peg$c106 = peg$literalExpectation("gone", true),
+      peg$c107 = function() { return { constant: null } },
+      peg$c108 = "mysterious",
+      peg$c109 = peg$literalExpectation("mysterious", false),
+      peg$c110 = function() { return '__MYSTERIOUS__' },
+      peg$c111 = "-",
+      peg$c112 = peg$literalExpectation("-", false),
+      peg$c113 = /^[0-9]/,
+      peg$c114 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c115 = ".",
+      peg$c116 = peg$literalExpectation(".", false),
+      peg$c117 = function(n) { return {number: parseFloat(n)} },
+      peg$c118 = function(n) { return {number: parseFloat(n) } },
+      peg$c119 = "\"",
+      peg$c120 = peg$literalExpectation("\"", false),
+      peg$c121 = /^[^"]/,
+      peg$c122 = peg$classExpectation(["\""], true, false),
+      peg$c123 = function(s) { return {string: s}},
+      peg$c124 = "nor",
+      peg$c125 = peg$literalExpectation("nor", false),
+      peg$c126 = function(lhs, rhs) {
       	return { 'nor' : { lhs: lhs, rhs: rhs } } },
-      peg$c126 = "or",
-      peg$c127 = peg$literalExpectation("or", false),
-      peg$c128 = function(lhs, rhs) {
+      peg$c127 = "or",
+      peg$c128 = peg$literalExpectation("or", false),
+      peg$c129 = function(lhs, rhs) {
       	return { 'or': {
               lhs: lhs,
               rhs: rhs
           } }
        },
-      peg$c129 = function(lhs, rhs) {
+      peg$c130 = function(lhs, rhs) {
       	return { 'and': {
               lhs: lhs,
               rhs: rhs
           } }
        },
-      peg$c130 = "aint",
-      peg$c131 = peg$literalExpectation("aint", true),
-      peg$c132 = "ain't",
-      peg$c133 = peg$literalExpectation("ain't", true),
-      peg$c134 = function() { return 'ne' },
-      peg$c135 = "is",
-      peg$c136 = peg$literalExpectation("is", true),
-      peg$c137 = function() { return 'eq' },
-      peg$c138 = function(lhs, c, rhs) {
+      peg$c131 = "aint",
+      peg$c132 = peg$literalExpectation("aint", true),
+      peg$c133 = "ain't",
+      peg$c134 = peg$literalExpectation("ain't", true),
+      peg$c135 = function() { return 'ne' },
+      peg$c136 = "is",
+      peg$c137 = peg$literalExpectation("is", true),
+      peg$c138 = function() { return 'eq' },
+      peg$c139 = function(lhs, c, rhs) {
             return {
                 comparison: {
                     comparator: c,
@@ -323,213 +324,213 @@ function peg$parse(input, options) {
                   }
               };
           },
-      peg$c139 = "not",
-      peg$c140 = peg$literalExpectation("not", false),
-      peg$c141 = function(e) { return { 'not': { expression: e} } },
-      peg$c142 = "higher",
-      peg$c143 = peg$literalExpectation("higher", true),
-      peg$c144 = "greater",
-      peg$c145 = peg$literalExpectation("greater", true),
-      peg$c146 = "bigger",
-      peg$c147 = peg$literalExpectation("bigger", true),
-      peg$c148 = "stronger",
-      peg$c149 = peg$literalExpectation("stronger", true),
-      peg$c150 = "lower",
-      peg$c151 = peg$literalExpectation("lower", true),
-      peg$c152 = "less",
-      peg$c153 = peg$literalExpectation("less", true),
-      peg$c154 = "smaller",
-      peg$c155 = peg$literalExpectation("smaller", true),
-      peg$c156 = "weaker",
-      peg$c157 = peg$literalExpectation("weaker", true),
-      peg$c158 = "high",
-      peg$c159 = peg$literalExpectation("high", true),
-      peg$c160 = "great",
-      peg$c161 = peg$literalExpectation("great", true),
-      peg$c162 = "big",
-      peg$c163 = peg$literalExpectation("big", true),
-      peg$c164 = "strong",
-      peg$c165 = peg$literalExpectation("strong", true),
-      peg$c166 = "low",
-      peg$c167 = peg$literalExpectation("low", true),
-      peg$c168 = "small",
-      peg$c169 = peg$literalExpectation("small", true),
-      peg$c170 = "weak",
-      peg$c171 = peg$literalExpectation("weak", true),
-      peg$c172 = "than",
-      peg$c173 = peg$literalExpectation("than", true),
-      peg$c174 = function() { return 'gt' },
-      peg$c175 = function() { return 'lt' },
-      peg$c176 = "as",
-      peg$c177 = peg$literalExpectation("as", true),
-      peg$c178 = function() { return 'ge' },
-      peg$c179 = function() { return 'le' },
-      peg$c180 = function(first, rest) { return rest.reduce(function(memo, curr) {
+      peg$c140 = "not",
+      peg$c141 = peg$literalExpectation("not", false),
+      peg$c142 = function(e) { return { 'not': { expression: e} } },
+      peg$c143 = "higher",
+      peg$c144 = peg$literalExpectation("higher", true),
+      peg$c145 = "greater",
+      peg$c146 = peg$literalExpectation("greater", true),
+      peg$c147 = "bigger",
+      peg$c148 = peg$literalExpectation("bigger", true),
+      peg$c149 = "stronger",
+      peg$c150 = peg$literalExpectation("stronger", true),
+      peg$c151 = "lower",
+      peg$c152 = peg$literalExpectation("lower", true),
+      peg$c153 = "less",
+      peg$c154 = peg$literalExpectation("less", true),
+      peg$c155 = "smaller",
+      peg$c156 = peg$literalExpectation("smaller", true),
+      peg$c157 = "weaker",
+      peg$c158 = peg$literalExpectation("weaker", true),
+      peg$c159 = "high",
+      peg$c160 = peg$literalExpectation("high", true),
+      peg$c161 = "great",
+      peg$c162 = peg$literalExpectation("great", true),
+      peg$c163 = "big",
+      peg$c164 = peg$literalExpectation("big", true),
+      peg$c165 = "strong",
+      peg$c166 = peg$literalExpectation("strong", true),
+      peg$c167 = "low",
+      peg$c168 = peg$literalExpectation("low", true),
+      peg$c169 = "small",
+      peg$c170 = peg$literalExpectation("small", true),
+      peg$c171 = "weak",
+      peg$c172 = peg$literalExpectation("weak", true),
+      peg$c173 = "than",
+      peg$c174 = peg$literalExpectation("than", true),
+      peg$c175 = function() { return 'gt' },
+      peg$c176 = function() { return 'lt' },
+      peg$c177 = "as",
+      peg$c178 = peg$literalExpectation("as", true),
+      peg$c179 = function() { return 'ge' },
+      peg$c180 = function() { return 'le' },
+      peg$c181 = function(first, rest) { return rest.reduce(function(memo, curr) {
                             return { binary: { op: curr[0], left: memo, right: curr[1]} };
                       }, first); },
-      peg$c181 = function(first, rest) { return rest.reduce(function(memo, curr) {
+      peg$c182 = function(first, rest) { return rest.reduce(function(memo, curr) {
                           return { binary: { op: curr[0], left: memo, right: curr[1]} };
                       }, first); },
-      peg$c182 = "+",
-      peg$c183 = peg$literalExpectation("+", false),
-      peg$c184 = "plus ",
-      peg$c185 = peg$literalExpectation("plus ", false),
-      peg$c186 = "with ",
-      peg$c187 = peg$literalExpectation("with ", false),
-      peg$c188 = function() { return '+' },
-      peg$c189 = "minus ",
-      peg$c190 = peg$literalExpectation("minus ", false),
-      peg$c191 = "without ",
-      peg$c192 = peg$literalExpectation("without ", false),
-      peg$c193 = function() { return '-' },
-      peg$c194 = "*",
-      peg$c195 = peg$literalExpectation("*", false),
-      peg$c196 = "times ",
-      peg$c197 = peg$literalExpectation("times ", false),
-      peg$c198 = "of ",
-      peg$c199 = peg$literalExpectation("of ", false),
-      peg$c200 = function() { return '*' },
-      peg$c201 = "/",
-      peg$c202 = peg$literalExpectation("/", false),
-      peg$c203 = "over ",
-      peg$c204 = peg$literalExpectation("over ", false),
-      peg$c205 = "between ",
-      peg$c206 = peg$literalExpectation("between ", false),
-      peg$c207 = function() { return '/' },
-      peg$c208 = "they",
-      peg$c209 = peg$literalExpectation("they", true),
-      peg$c210 = "them",
-      peg$c211 = peg$literalExpectation("them", true),
-      peg$c212 = "she",
-      peg$c213 = peg$literalExpectation("she", true),
-      peg$c214 = "him",
-      peg$c215 = peg$literalExpectation("him", true),
-      peg$c216 = "her",
-      peg$c217 = peg$literalExpectation("her", true),
-      peg$c218 = "hir",
-      peg$c219 = peg$literalExpectation("hir", true),
-      peg$c220 = "zie",
-      peg$c221 = peg$literalExpectation("zie", true),
-      peg$c222 = "zir",
-      peg$c223 = peg$literalExpectation("zir", true),
-      peg$c224 = "xem",
-      peg$c225 = peg$literalExpectation("xem", true),
-      peg$c226 = "ver",
-      peg$c227 = peg$literalExpectation("ver", true),
-      peg$c228 = "ze",
-      peg$c229 = peg$literalExpectation("ze", true),
-      peg$c230 = "ve",
-      peg$c231 = peg$literalExpectation("ve", true),
-      peg$c232 = "xe",
-      peg$c233 = peg$literalExpectation("xe", true),
-      peg$c234 = "it",
-      peg$c235 = peg$literalExpectation("it", true),
-      peg$c236 = "he",
-      peg$c237 = peg$literalExpectation("he", true),
-      peg$c238 = function(pronoun) { return { pronoun: pronoun.toLowerCase() } },
-      peg$c239 = function(v) { return { lookup: { variable: v } }; },
-      peg$c240 = "an",
-      peg$c241 = peg$literalExpectation("an", true),
-      peg$c242 = "a",
-      peg$c243 = peg$literalExpectation("a", true),
-      peg$c244 = "the",
-      peg$c245 = peg$literalExpectation("the", true),
-      peg$c246 = "my",
-      peg$c247 = peg$literalExpectation("my", true),
-      peg$c248 = "your",
-      peg$c249 = peg$literalExpectation("your", true),
-      peg$c250 = /^[A-Z\xC0\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB\xCC\xCD\xCE\xCF\xD0\xD1\xD2\xD3\xD4\xD5\xD6\xD8\xD9\xDA\xDB\xDC\xDD\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0138\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178\u0179\u017B\u017D]/,
-      peg$c251 = peg$classExpectation([["A", "Z"], "\xC0", "\xC1", "\xC2", "\xC3", "\xC4", "\xC5", "\xC6", "\xC7", "\xC8", "\xC9", "\xCA", "\xCB", "\xCC", "\xCD", "\xCE", "\xCF", "\xD0", "\xD1", "\xD2", "\xD3", "\xD4", "\xD5", "\xD6", "\xD8", "\xD9", "\xDA", "\xDB", "\xDC", "\xDD", "\xDE", "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0138", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", "\u0178", "\u0179", "\u017B", "\u017D"], false, false),
-      peg$c252 = /^[a-z\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF8\xF9\xFA\xFB\xFC\xFD\xFE\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\xFF\u017A\u017C\u017E\u0149\xDF]/,
-      peg$c253 = peg$classExpectation([["a", "z"], "\xE0", "\xE1", "\xE2", "\xE3", "\xE4", "\xE5", "\xE6", "\xE7", "\xE8", "\xE9", "\xEA", "\xEB", "\xEC", "\xED", "\xEE", "\xEF", "\xF0", "\xF1", "\xF2", "\xF3", "\xF4", "\xF5", "\xF6", "\xF8", "\xF9", "\xFA", "\xFB", "\xFC", "\xFD", "\xFE", "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", "\u0137", "\u0138", "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", "\u0148", "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\xFF", "\u017A", "\u017C", "\u017E", "\u0149", "\xDF"], false, false),
-      peg$c254 = function(prefix, name) { return (prefix + '_' + name).toLowerCase() },
-      peg$c255 = "'s",
-      peg$c256 = peg$literalExpectation("'s", false),
-      peg$c257 = "=",
-      peg$c258 = peg$literalExpectation("=", false),
-      peg$c259 = "is ",
-      peg$c260 = peg$literalExpectation("is ", true),
-      peg$c261 = "was ",
-      peg$c262 = peg$literalExpectation("was ", true),
-      peg$c263 = "are ",
-      peg$c264 = peg$literalExpectation("are ", true),
-      peg$c265 = "were ",
-      peg$c266 = peg$literalExpectation("were ", true),
-      peg$c267 = function(v, e) { return { assign: { variable: v, expression: e} }; },
-      peg$c268 = "says ",
-      peg$c269 = peg$literalExpectation("says ", true),
-      peg$c270 = "put",
-      peg$c271 = peg$literalExpectation("put", true),
-      peg$c272 = "into",
-      peg$c273 = peg$literalExpectation("into", true),
-      peg$c274 = function(e, v) { return { assign: { variable: v, expression: e} }; },
-      peg$c275 = function(s) { return { string: s} },
-      peg$c276 = function(n, d) { return { number: parseFloat(d?n+'.'+d:n)}},
-      peg$c277 = function(d) {return d},
-      peg$c278 = /^[0-9',;:?!+_\-\/]/,
-      peg$c279 = peg$classExpectation([["0", "9"], "'", ",", ";", ":", "?", "!", "+", "_", "-", "/"], false, false),
-      peg$c280 = function(head, tail) { return head + tail },
-      peg$c281 = function(d) { return d },
-      peg$c282 = /^[A-Za-z']/,
-      peg$c283 = peg$classExpectation([["A", "Z"], ["a", "z"], "'"], false, false),
-      peg$c284 = function(t) { return (t.filter(c => /[A-Za-z]/.test(c)).length%10).toString()},
-      peg$c285 = peg$literalExpectation("mysterious", true),
-      peg$c286 = "between",
-      peg$c287 = peg$literalExpectation("between", true),
-      peg$c288 = "without",
-      peg$c289 = peg$literalExpectation("without", true),
-      peg$c290 = "build",
-      peg$c291 = peg$literalExpectation("build", true),
-      peg$c292 = "knock",
-      peg$c293 = peg$literalExpectation("knock", true),
-      peg$c294 = "take ",
-      peg$c295 = peg$literalExpectation("take ", true),
-      peg$c296 = "times",
-      peg$c297 = peg$literalExpectation("times", true),
-      peg$c298 = "minus",
-      peg$c299 = peg$literalExpectation("minus", true),
-      peg$c300 = "back",
-      peg$c301 = peg$literalExpectation("back", true),
-      peg$c302 = "down",
-      peg$c303 = peg$literalExpectation("down", true),
-      peg$c304 = "give",
-      peg$c305 = peg$literalExpectation("give", true),
-      peg$c306 = "plus",
-      peg$c307 = peg$literalExpectation("plus", true),
-      peg$c308 = "says",
-      peg$c309 = peg$literalExpectation("says", true),
-      peg$c310 = "were",
-      peg$c311 = peg$literalExpectation("were", true),
-      peg$c312 = "over",
-      peg$c313 = peg$literalExpectation("over", true),
-      peg$c314 = "with",
-      peg$c315 = peg$literalExpectation("with", true),
-      peg$c316 = peg$literalExpectation("and", true),
-      peg$c317 = "it ",
-      peg$c318 = peg$literalExpectation("it ", true),
-      peg$c319 = peg$literalExpectation("nor", true),
-      peg$c320 = peg$literalExpectation("not", true),
-      peg$c321 = "top",
-      peg$c322 = peg$literalExpectation("top", true),
-      peg$c323 = "was",
-      peg$c324 = peg$literalExpectation("was", true),
-      peg$c325 = "of",
-      peg$c326 = peg$literalExpectation("of", true),
-      peg$c327 = peg$literalExpectation("or", true),
-      peg$c328 = "to",
-      peg$c329 = peg$literalExpectation("to", true),
-      peg$c330 = "up",
-      peg$c331 = peg$literalExpectation("up", true),
-      peg$c332 = " ",
-      peg$c333 = peg$literalExpectation(" ", false),
-      peg$c334 = function(head) { return head.replace(/ /g, '_').toUpperCase()  },
-      peg$c335 = function(v, t) { return {
+      peg$c183 = "+",
+      peg$c184 = peg$literalExpectation("+", false),
+      peg$c185 = "plus ",
+      peg$c186 = peg$literalExpectation("plus ", false),
+      peg$c187 = "with ",
+      peg$c188 = peg$literalExpectation("with ", false),
+      peg$c189 = function() { return '+' },
+      peg$c190 = "minus ",
+      peg$c191 = peg$literalExpectation("minus ", false),
+      peg$c192 = "without ",
+      peg$c193 = peg$literalExpectation("without ", false),
+      peg$c194 = function() { return '-' },
+      peg$c195 = "*",
+      peg$c196 = peg$literalExpectation("*", false),
+      peg$c197 = "times ",
+      peg$c198 = peg$literalExpectation("times ", false),
+      peg$c199 = "of ",
+      peg$c200 = peg$literalExpectation("of ", false),
+      peg$c201 = function() { return '*' },
+      peg$c202 = "/",
+      peg$c203 = peg$literalExpectation("/", false),
+      peg$c204 = "over ",
+      peg$c205 = peg$literalExpectation("over ", false),
+      peg$c206 = "between ",
+      peg$c207 = peg$literalExpectation("between ", false),
+      peg$c208 = function() { return '/' },
+      peg$c209 = "they",
+      peg$c210 = peg$literalExpectation("they", true),
+      peg$c211 = "them",
+      peg$c212 = peg$literalExpectation("them", true),
+      peg$c213 = "she",
+      peg$c214 = peg$literalExpectation("she", true),
+      peg$c215 = "him",
+      peg$c216 = peg$literalExpectation("him", true),
+      peg$c217 = "her",
+      peg$c218 = peg$literalExpectation("her", true),
+      peg$c219 = "hir",
+      peg$c220 = peg$literalExpectation("hir", true),
+      peg$c221 = "zie",
+      peg$c222 = peg$literalExpectation("zie", true),
+      peg$c223 = "zir",
+      peg$c224 = peg$literalExpectation("zir", true),
+      peg$c225 = "xem",
+      peg$c226 = peg$literalExpectation("xem", true),
+      peg$c227 = "ver",
+      peg$c228 = peg$literalExpectation("ver", true),
+      peg$c229 = "ze",
+      peg$c230 = peg$literalExpectation("ze", true),
+      peg$c231 = "ve",
+      peg$c232 = peg$literalExpectation("ve", true),
+      peg$c233 = "xe",
+      peg$c234 = peg$literalExpectation("xe", true),
+      peg$c235 = "it",
+      peg$c236 = peg$literalExpectation("it", true),
+      peg$c237 = "he",
+      peg$c238 = peg$literalExpectation("he", true),
+      peg$c239 = function(pronoun) { return { pronoun: pronoun.toLowerCase() } },
+      peg$c240 = function(v) { return { lookup: { variable: v } }; },
+      peg$c241 = "an",
+      peg$c242 = peg$literalExpectation("an", true),
+      peg$c243 = "a",
+      peg$c244 = peg$literalExpectation("a", true),
+      peg$c245 = "the",
+      peg$c246 = peg$literalExpectation("the", true),
+      peg$c247 = "my",
+      peg$c248 = peg$literalExpectation("my", true),
+      peg$c249 = "your",
+      peg$c250 = peg$literalExpectation("your", true),
+      peg$c251 = /^[A-Z\xC0\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB\xCC\xCD\xCE\xCF\xD0\xD1\xD2\xD3\xD4\xD5\xD6\xD8\xD9\xDA\xDB\xDC\xDD\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0138\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178\u0179\u017B\u017D]/,
+      peg$c252 = peg$classExpectation([["A", "Z"], "\xC0", "\xC1", "\xC2", "\xC3", "\xC4", "\xC5", "\xC6", "\xC7", "\xC8", "\xC9", "\xCA", "\xCB", "\xCC", "\xCD", "\xCE", "\xCF", "\xD0", "\xD1", "\xD2", "\xD3", "\xD4", "\xD5", "\xD6", "\xD8", "\xD9", "\xDA", "\xDB", "\xDC", "\xDD", "\xDE", "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0138", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", "\u0178", "\u0179", "\u017B", "\u017D"], false, false),
+      peg$c253 = /^[a-z\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF8\xF9\xFA\xFB\xFC\xFD\xFE\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\xFF\u017A\u017C\u017E\u0149\xDF]/,
+      peg$c254 = peg$classExpectation([["a", "z"], "\xE0", "\xE1", "\xE2", "\xE3", "\xE4", "\xE5", "\xE6", "\xE7", "\xE8", "\xE9", "\xEA", "\xEB", "\xEC", "\xED", "\xEE", "\xEF", "\xF0", "\xF1", "\xF2", "\xF3", "\xF4", "\xF5", "\xF6", "\xF8", "\xF9", "\xFA", "\xFB", "\xFC", "\xFD", "\xFE", "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", "\u0137", "\u0138", "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", "\u0148", "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\xFF", "\u017A", "\u017C", "\u017E", "\u0149", "\xDF"], false, false),
+      peg$c255 = function(prefix, name) { return (prefix + '_' + name).toLowerCase() },
+      peg$c256 = "'s",
+      peg$c257 = peg$literalExpectation("'s", false),
+      peg$c258 = "=",
+      peg$c259 = peg$literalExpectation("=", false),
+      peg$c260 = "is ",
+      peg$c261 = peg$literalExpectation("is ", true),
+      peg$c262 = "was ",
+      peg$c263 = peg$literalExpectation("was ", true),
+      peg$c264 = "are ",
+      peg$c265 = peg$literalExpectation("are ", true),
+      peg$c266 = "were ",
+      peg$c267 = peg$literalExpectation("were ", true),
+      peg$c268 = function(v, e) { return { assign: { variable: v, expression: e} }; },
+      peg$c269 = "says ",
+      peg$c270 = peg$literalExpectation("says ", true),
+      peg$c271 = "put",
+      peg$c272 = peg$literalExpectation("put", true),
+      peg$c273 = "into",
+      peg$c274 = peg$literalExpectation("into", true),
+      peg$c275 = function(e, v) { return { assign: { variable: v, expression: e} }; },
+      peg$c276 = function(s) { return { string: s} },
+      peg$c277 = function(n, d) { return { number: parseFloat(d?n+'.'+d:n)}},
+      peg$c278 = function(d) {return d},
+      peg$c279 = /^[0-9',;:?!+_\-\/]/,
+      peg$c280 = peg$classExpectation([["0", "9"], "'", ",", ";", ":", "?", "!", "+", "_", "-", "/"], false, false),
+      peg$c281 = function(head, tail) { return head + tail },
+      peg$c282 = function(d) { return d },
+      peg$c283 = /^[A-Za-z']/,
+      peg$c284 = peg$classExpectation([["A", "Z"], ["a", "z"], "'"], false, false),
+      peg$c285 = function(t) { return (t.filter(c => /[A-Za-z]/.test(c)).length%10).toString()},
+      peg$c286 = peg$literalExpectation("mysterious", true),
+      peg$c287 = "between",
+      peg$c288 = peg$literalExpectation("between", true),
+      peg$c289 = "without",
+      peg$c290 = peg$literalExpectation("without", true),
+      peg$c291 = "build",
+      peg$c292 = peg$literalExpectation("build", true),
+      peg$c293 = "knock",
+      peg$c294 = peg$literalExpectation("knock", true),
+      peg$c295 = "take ",
+      peg$c296 = peg$literalExpectation("take ", true),
+      peg$c297 = "times",
+      peg$c298 = peg$literalExpectation("times", true),
+      peg$c299 = "minus",
+      peg$c300 = peg$literalExpectation("minus", true),
+      peg$c301 = "back",
+      peg$c302 = peg$literalExpectation("back", true),
+      peg$c303 = "down",
+      peg$c304 = peg$literalExpectation("down", true),
+      peg$c305 = "give",
+      peg$c306 = peg$literalExpectation("give", true),
+      peg$c307 = "plus",
+      peg$c308 = peg$literalExpectation("plus", true),
+      peg$c309 = "says",
+      peg$c310 = peg$literalExpectation("says", true),
+      peg$c311 = "were",
+      peg$c312 = peg$literalExpectation("were", true),
+      peg$c313 = "over",
+      peg$c314 = peg$literalExpectation("over", true),
+      peg$c315 = "with",
+      peg$c316 = peg$literalExpectation("with", true),
+      peg$c317 = peg$literalExpectation("and", true),
+      peg$c318 = "it ",
+      peg$c319 = peg$literalExpectation("it ", true),
+      peg$c320 = peg$literalExpectation("nor", true),
+      peg$c321 = peg$literalExpectation("not", true),
+      peg$c322 = "top",
+      peg$c323 = peg$literalExpectation("top", true),
+      peg$c324 = "was",
+      peg$c325 = peg$literalExpectation("was", true),
+      peg$c326 = "of",
+      peg$c327 = peg$literalExpectation("of", true),
+      peg$c328 = peg$literalExpectation("or", true),
+      peg$c329 = "to",
+      peg$c330 = peg$literalExpectation("to", true),
+      peg$c331 = "up",
+      peg$c332 = peg$literalExpectation("up", true),
+      peg$c333 = " ",
+      peg$c334 = peg$literalExpectation(" ", false),
+      peg$c335 = function(head) { return head.replace(/ /g, '_').toUpperCase()  },
+      peg$c336 = function(v, t) { return {
             increment: {
                 variable: v,
                   multiple: t.length
               }
           }; },
-      peg$c336 = function(v, t) { return {
+      peg$c337 = function(v, t) { return {
             decrement: {
                 variable: v,
                   multiple: t.length
@@ -714,6 +715,9 @@ function peg$parse(input, options) {
         } else {
           s3 = peg$FAILED;
         }
+        if (s3 === peg$FAILED) {
+          s3 = peg$parseEOF();
+        }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c1(s2);
@@ -887,6 +891,29 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseEOF() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    peg$silentFails++;
+    if (input.length > peg$currPos) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c15); }
+    }
+    peg$silentFails--;
+    if (s1 === peg$FAILED) {
+      s0 = void 0;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseignore_rest_of_line() {
     var s0, s1, s2, s3;
 
@@ -894,21 +921,21 @@ function peg$parse(input, options) {
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c15.test(input.charAt(peg$currPos))) {
+      if (peg$c16.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c16); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        if (peg$c15.test(input.charAt(peg$currPos))) {
+        if (peg$c16.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c17); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -985,18 +1012,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c17) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c18) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c18); }
+      if (peg$silentFails === 0) { peg$fail(peg$c19); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseignore_rest_of_line();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c19();
+        s1 = peg$c20();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1015,12 +1042,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c20) {
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c21) {
       s2 = input.substr(peg$currPos, 8);
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      if (peg$silentFails === 0) { peg$fail(peg$c22); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parseignore_rest_of_line();
@@ -1036,17 +1063,17 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 18).toLowerCase() === peg$c22) {
+      if (input.substr(peg$currPos, 18).toLowerCase() === peg$c23) {
         s1 = input.substr(peg$currPos, 18);
         peg$currPos += 18;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c23); }
+        if (peg$silentFails === 0) { peg$fail(peg$c24); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c24();
+      s1 = peg$c25();
     }
     s0 = s1;
 
@@ -1061,12 +1088,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c25) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c26) {
           s3 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c26); }
+          if (peg$silentFails === 0) { peg$fail(peg$c27); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -1078,7 +1105,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseblock();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c27(s1, s5, s7);
+                  s1 = peg$c28(s1, s5, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1121,12 +1148,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c28) {
-        s2 = peg$c28;
+      if (input.substr(peg$currPos, 5) === peg$c29) {
+        s2 = peg$c29;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -1152,36 +1179,36 @@ function peg$parse(input, options) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c30) {
-          s2 = peg$c30;
+        if (input.substr(peg$currPos, 3) === peg$c31) {
+          s2 = peg$c31;
           peg$currPos += 3;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s2 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 38) {
-            s2 = peg$c32;
+            s2 = peg$c33;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c33); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s2 = peg$c34;
+              s2 = peg$c35;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c35); }
+              if (peg$silentFails === 0) { peg$fail(peg$c36); }
             }
             if (s2 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c36) {
-                s2 = peg$c36;
+              if (input.substr(peg$currPos, 3) === peg$c37) {
+                s2 = peg$c37;
                 peg$currPos += 3;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c37); }
+                if (peg$silentFails === 0) { peg$fail(peg$c38); }
               }
             }
           }
@@ -1222,7 +1249,7 @@ function peg$parse(input, options) {
         s3 = peg$parsearg_list();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c38(s1, s3);
+          s1 = peg$c39(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1241,7 +1268,7 @@ function peg$parse(input, options) {
       s1 = peg$parsevariable();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s1);
+        s1 = peg$c40(s1);
       }
       s0 = s1;
     }
@@ -1258,12 +1285,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c28) {
-        s2 = peg$c28;
+      if (input.substr(peg$currPos, 5) === peg$c29) {
+        s2 = peg$c29;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -1290,27 +1317,27 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 38) {
-          s2 = peg$c32;
+          s2 = peg$c33;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+          if (peg$silentFails === 0) { peg$fail(peg$c34); }
         }
         if (s2 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s2 = peg$c34;
+            s2 = peg$c35;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c36); }
           }
           if (s2 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c36) {
-              s2 = peg$c36;
+            if (input.substr(peg$currPos, 3) === peg$c37) {
+              s2 = peg$c37;
               peg$currPos += 3;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c37); }
+              if (peg$silentFails === 0) { peg$fail(peg$c38); }
             }
           }
         }
@@ -1350,7 +1377,7 @@ function peg$parse(input, options) {
         s3 = peg$parsearg_list();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c38(s1, s3);
+          s1 = peg$c39(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1369,7 +1396,7 @@ function peg$parse(input, options) {
       s1 = peg$parsevariable();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s1);
+        s1 = peg$c40(s1);
       }
       s0 = s1;
     }
@@ -1385,12 +1412,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c40) {
+        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c41) {
           s3 = input.substr(peg$currPos, 6);
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c42); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -1398,7 +1425,7 @@ function peg$parse(input, options) {
             s5 = peg$parsecall_args();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c42(s1, s5);
+              s1 = peg$c43(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1435,7 +1462,7 @@ function peg$parse(input, options) {
         s3 = peg$parsecall_args();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c38(s1, s3);
+          s1 = peg$c39(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1454,7 +1481,7 @@ function peg$parse(input, options) {
       s1 = peg$parsesimple_expression();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s1);
+        s1 = peg$c40(s1);
       }
       s0 = s1;
     }
@@ -1465,20 +1492,20 @@ function peg$parse(input, options) {
   function peg$parsereturn() {
     var s0;
 
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c43) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c44) {
       s0 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c44); }
+      if (peg$silentFails === 0) { peg$fail(peg$c45); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 9).toLowerCase() === peg$c45) {
+      if (input.substr(peg$currPos, 9).toLowerCase() === peg$c46) {
         s0 = input.substr(peg$currPos, 9);
         peg$currPos += 9;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
     }
 
@@ -1496,7 +1523,7 @@ function peg$parse(input, options) {
         s3 = peg$parsenor();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c47(s3);
+          s1 = peg$c48(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1535,12 +1562,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9).toLowerCase() === peg$c48) {
+    if (input.substr(peg$currPos, 9).toLowerCase() === peg$c49) {
       s1 = input.substr(peg$currPos, 9);
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1548,7 +1575,7 @@ function peg$parse(input, options) {
         s3 = peg$parsevariable();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c50(s3);
+          s1 = peg$c51(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1564,16 +1591,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c51) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c52) {
         s1 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c52); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c53();
+        s1 = peg$c54();
       }
       s0 = s1;
     }
@@ -1633,7 +1660,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c54(s1, s2);
+        s1 = peg$c55(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1703,12 +1730,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c55) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c56) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c56); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -1716,7 +1743,7 @@ function peg$parse(input, options) {
           s4 = peg$parsestatement();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c57(s4);
+            s1 = peg$c58(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1747,12 +1774,12 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c55) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c56) {
           s2 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c56); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -1760,7 +1787,7 @@ function peg$parse(input, options) {
             s4 = peg$parsestatement();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c57(s4);
+              s1 = peg$c58(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1791,12 +1818,12 @@ function peg$parse(input, options) {
           s1 = peg$FAILED;
         }
         if (s1 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c55) {
+          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c56) {
             s2 = input.substr(peg$currPos, 4);
             peg$currPos += 4;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c56); }
+            if (peg$silentFails === 0) { peg$fail(peg$c57); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parseEOL();
@@ -1804,7 +1831,7 @@ function peg$parse(input, options) {
               s4 = peg$parseblock();
               if (s4 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c57(s4);
+                s1 = peg$c58(s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1841,12 +1868,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c59) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c60); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1864,7 +1891,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c60(s3, s4, s5);
+              s1 = peg$c61(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1941,12 +1968,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c62) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c63); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1956,7 +1983,7 @@ function peg$parse(input, options) {
           s4 = peg$parseloopable();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c63(s3, s4);
+            s1 = peg$c64(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1976,12 +2003,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c64) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c65) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1991,7 +2018,7 @@ function peg$parse(input, options) {
             s4 = peg$parseloopable();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c66(s3, s4);
+              s1 = peg$c67(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2018,36 +2045,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c67) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c68) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c68); }
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c69) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c70) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c71) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c72) {
           s1 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c73) {
+          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c74) {
             s1 = input.substr(peg$currPos, 6);
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c75); }
           }
         }
       }
@@ -2058,7 +2085,7 @@ function peg$parse(input, options) {
         s3 = peg$parsenor();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c75(s3);
+          s1 = peg$c76(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2131,43 +2158,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c76) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c77) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c77); }
+      if (peg$silentFails === 0) { peg$fail(peg$c78); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c78) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c79) {
         s1 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c80) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c81) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c82) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c83) {
             s1 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c83); }
+            if (peg$silentFails === 0) { peg$fail(peg$c84); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c84();
+      s1 = peg$c85();
     }
     s0 = s1;
 
@@ -2178,43 +2205,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c85) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c86) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
+      if (peg$silentFails === 0) { peg$fail(peg$c87); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c88) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c88); }
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c89) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c90) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c90); }
+          if (peg$silentFails === 0) { peg$fail(peg$c91); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c91) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c92) {
             s1 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c92); }
+            if (peg$silentFails === 0) { peg$fail(peg$c93); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c93();
+      s1 = peg$c94();
     }
     s0 = s1;
 
@@ -2225,52 +2252,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c94) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c95) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c95); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c96) {
+      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c97) {
         s1 = input.substr(peg$currPos, 7);
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c98); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c98) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c99) {
           s1 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+          if (peg$silentFails === 0) { peg$fail(peg$c100); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c100) {
+          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c101) {
             s1 = input.substr(peg$currPos, 6);
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c102); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c102) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c103) {
               s1 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c103); }
+              if (peg$silentFails === 0) { peg$fail(peg$c104); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c104) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c105) {
                 s1 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                if (peg$silentFails === 0) { peg$fail(peg$c106); }
               }
             }
           }
@@ -2279,7 +2306,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c106();
+      s1 = peg$c107();
     }
     s0 = s1;
 
@@ -2290,16 +2317,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 10) === peg$c107) {
-      s1 = peg$c107;
+    if (input.substr(peg$currPos, 10) === peg$c108) {
+      s1 = peg$c108;
       peg$currPos += 10;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c108); }
+      if (peg$silentFails === 0) { peg$fail(peg$c109); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c109();
+      s1 = peg$c110();
     }
     s0 = s1;
 
@@ -2313,33 +2340,33 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s3 = peg$c110;
+      s3 = peg$c111;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      if (peg$silentFails === 0) { peg$fail(peg$c112); }
     }
     if (s3 === peg$FAILED) {
       s3 = null;
     }
     if (s3 !== peg$FAILED) {
       s4 = [];
-      if (peg$c112.test(input.charAt(peg$currPos))) {
+      if (peg$c113.test(input.charAt(peg$currPos))) {
         s5 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
       if (s5 !== peg$FAILED) {
         while (s5 !== peg$FAILED) {
           s4.push(s5);
-          if (peg$c112.test(input.charAt(peg$currPos))) {
+          if (peg$c113.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c113); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
         }
       } else {
@@ -2348,30 +2375,30 @@ function peg$parse(input, options) {
       if (s4 !== peg$FAILED) {
         s5 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s6 = peg$c114;
+          s6 = peg$c115;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c116); }
         }
         if (s6 !== peg$FAILED) {
           s7 = [];
-          if (peg$c112.test(input.charAt(peg$currPos))) {
+          if (peg$c113.test(input.charAt(peg$currPos))) {
             s8 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s8 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c113); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s8 !== peg$FAILED) {
             while (s8 !== peg$FAILED) {
               s7.push(s8);
-              if (peg$c112.test(input.charAt(peg$currPos))) {
+              if (peg$c113.test(input.charAt(peg$currPos))) {
                 s8 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s8 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c113); }
+                if (peg$silentFails === 0) { peg$fail(peg$c114); }
               }
             }
           } else {
@@ -2413,18 +2440,18 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c114;
+        s2 = peg$c115;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c116(s1);
+        s1 = peg$c117(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2439,30 +2466,30 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c114;
+        s3 = peg$c115;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c112.test(input.charAt(peg$currPos))) {
+        if (peg$c113.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c113); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c112.test(input.charAt(peg$currPos))) {
+            if (peg$c113.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c113); }
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
             }
           }
         } else {
@@ -2486,7 +2513,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c117(s1);
+        s1 = peg$c118(s1);
       }
       s0 = s1;
     }
@@ -2499,30 +2526,30 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c118;
+      s1 = peg$c119;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = [];
-      if (peg$c120.test(input.charAt(peg$currPos))) {
+      if (peg$c121.test(input.charAt(peg$currPos))) {
         s4 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c122); }
       }
       while (s4 !== peg$FAILED) {
         s3.push(s4);
-        if (peg$c120.test(input.charAt(peg$currPos))) {
+        if (peg$c121.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c122); }
         }
       }
       if (s3 !== peg$FAILED) {
@@ -2532,15 +2559,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c118;
+          s3 = peg$c119;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c119); }
+          if (peg$silentFails === 0) { peg$fail(peg$c120); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c122(s2);
+          s1 = peg$c123(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2566,12 +2593,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c123) {
-          s3 = peg$c123;
+        if (input.substr(peg$currPos, 3) === peg$c124) {
+          s3 = peg$c124;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c124); }
+          if (peg$silentFails === 0) { peg$fail(peg$c125); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -2579,7 +2606,7 @@ function peg$parse(input, options) {
             s5 = peg$parsenor();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c125(s1, s5);
+              s1 = peg$c126(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2616,12 +2643,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c126) {
-          s3 = peg$c126;
+        if (input.substr(peg$currPos, 2) === peg$c127) {
+          s3 = peg$c127;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c127); }
+          if (peg$silentFails === 0) { peg$fail(peg$c128); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -2629,7 +2656,7 @@ function peg$parse(input, options) {
             s5 = peg$parseor();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c128(s1, s5);
+              s1 = peg$c129(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2666,12 +2693,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c30) {
-          s3 = peg$c30;
+        if (input.substr(peg$currPos, 3) === peg$c31) {
+          s3 = peg$c31;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -2679,7 +2706,7 @@ function peg$parse(input, options) {
             s5 = peg$parseand();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c129(s1, s5);
+              s1 = peg$c130(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2712,39 +2739,39 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c131) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
+      if (peg$silentFails === 0) { peg$fail(peg$c132); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c132) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c133) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c134); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c134();
+      s1 = peg$c135();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c135) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c136) {
         s1 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c136); }
+        if (peg$silentFails === 0) { peg$fail(peg$c137); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c137();
+        s1 = peg$c138();
       }
       s0 = s1;
     }
@@ -2767,7 +2794,7 @@ function peg$parse(input, options) {
             s5 = peg$parseequality_check();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c138(s1, s3, s5);
+              s1 = peg$c139(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2800,12 +2827,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2813,7 +2840,7 @@ function peg$parse(input, options) {
         s3 = peg$parsenot();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c141(s3);
+          s1 = peg$c142(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2849,7 +2876,7 @@ function peg$parse(input, options) {
             s5 = peg$parsecomparison();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c138(s1, s3, s5);
+              s1 = peg$c139(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2881,36 +2908,36 @@ function peg$parse(input, options) {
   function peg$parsegreater() {
     var s0;
 
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c142) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c143) {
       s0 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c144); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c144) {
+      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c145) {
         s0 = input.substr(peg$currPos, 7);
         peg$currPos += 7;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c145); }
+        if (peg$silentFails === 0) { peg$fail(peg$c146); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c146) {
+        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
           s0 = input.substr(peg$currPos, 6);
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c148); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 8).toLowerCase() === peg$c148) {
+          if (input.substr(peg$currPos, 8).toLowerCase() === peg$c149) {
             s0 = input.substr(peg$currPos, 8);
             peg$currPos += 8;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c149); }
+            if (peg$silentFails === 0) { peg$fail(peg$c150); }
           }
         }
       }
@@ -2922,36 +2949,36 @@ function peg$parse(input, options) {
   function peg$parsesmaller() {
     var s0;
 
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c150) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c151) {
       s0 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c152) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
         s0 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c153); }
+        if (peg$silentFails === 0) { peg$fail(peg$c154); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c154) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c155) {
           s0 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c156); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c156) {
+          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c157) {
             s0 = input.substr(peg$currPos, 6);
             peg$currPos += 6;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c157); }
+            if (peg$silentFails === 0) { peg$fail(peg$c158); }
           }
         }
       }
@@ -2963,36 +2990,36 @@ function peg$parse(input, options) {
   function peg$parsegreat() {
     var s0;
 
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c158) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c159) {
       s0 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
+      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c160) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c161) {
         s0 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c162); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c162) {
+        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c163) {
           s0 = input.substr(peg$currPos, 3);
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c163); }
+          if (peg$silentFails === 0) { peg$fail(peg$c164); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c164) {
+          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c165) {
             s0 = input.substr(peg$currPos, 6);
             peg$currPos += 6;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c165); }
+            if (peg$silentFails === 0) { peg$fail(peg$c166); }
           }
         }
       }
@@ -3004,28 +3031,28 @@ function peg$parse(input, options) {
   function peg$parsesmall() {
     var s0;
 
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c166) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c167) {
       s0 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c167); }
+      if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c168) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c169) {
         s0 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        if (peg$silentFails === 0) { peg$fail(peg$c170); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c170) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c171) {
           s0 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          if (peg$silentFails === 0) { peg$fail(peg$c172); }
         }
       }
     }
@@ -3037,12 +3064,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c135) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c136) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+      if (peg$silentFails === 0) { peg$fail(peg$c137); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3051,16 +3078,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c173) {
               s5 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c173); }
+              if (peg$silentFails === 0) { peg$fail(peg$c174); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c174();
+              s1 = peg$c175();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3084,12 +3111,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c135) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c136) {
         s1 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c136); }
+        if (peg$silentFails === 0) { peg$fail(peg$c137); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3098,16 +3125,16 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c173) {
                 s5 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c173); }
+                if (peg$silentFails === 0) { peg$fail(peg$c174); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c175();
+                s1 = peg$c176();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3131,22 +3158,22 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c135) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c136) {
           s1 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c136); }
+          if (peg$silentFails === 0) { peg$fail(peg$c137); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c176) {
+            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c177) {
               s3 = input.substr(peg$currPos, 2);
               peg$currPos += 2;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c177); }
+              if (peg$silentFails === 0) { peg$fail(peg$c178); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
@@ -3155,16 +3182,16 @@ function peg$parse(input, options) {
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parse_();
                   if (s6 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c176) {
+                    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c177) {
                       s7 = input.substr(peg$currPos, 2);
                       peg$currPos += 2;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c178); }
                     }
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c178();
+                      s1 = peg$c179();
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -3196,22 +3223,22 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c135) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c136) {
             s1 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c136); }
+            if (peg$silentFails === 0) { peg$fail(peg$c137); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c176) {
+              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c177) {
                 s3 = input.substr(peg$currPos, 2);
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c177); }
+                if (peg$silentFails === 0) { peg$fail(peg$c178); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -3220,16 +3247,16 @@ function peg$parse(input, options) {
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse_();
                     if (s6 !== peg$FAILED) {
-                      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c176) {
+                      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c177) {
                         s7 = input.substr(peg$currPos, 2);
                         peg$currPos += 2;
                       } else {
                         s7 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c177); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c178); }
                       }
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c179();
+                        s1 = peg$c180();
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3318,7 +3345,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c180(s1, s2);
+        s1 = peg$c181(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3387,7 +3414,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c181(s1, s2);
+        s1 = peg$c182(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3416,27 +3443,27 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s2 = peg$c182;
+        s2 = peg$c183;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c184) {
-          s2 = peg$c184;
+        if (input.substr(peg$currPos, 5) === peg$c185) {
+          s2 = peg$c185;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 5) === peg$c186) {
-            s2 = peg$c186;
+          if (input.substr(peg$currPos, 5) === peg$c187) {
+            s2 = peg$c187;
             peg$currPos += 5;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c187); }
+            if (peg$silentFails === 0) { peg$fail(peg$c188); }
           }
         }
       }
@@ -3449,7 +3476,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c188();
+          s1 = peg$c189();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3479,27 +3506,27 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c110;
+        s2 = peg$c111;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c112); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c189) {
-          s2 = peg$c189;
+        if (input.substr(peg$currPos, 6) === peg$c190) {
+          s2 = peg$c190;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c191); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 8) === peg$c191) {
-            s2 = peg$c191;
+          if (input.substr(peg$currPos, 8) === peg$c192) {
+            s2 = peg$c192;
             peg$currPos += 8;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c192); }
+            if (peg$silentFails === 0) { peg$fail(peg$c193); }
           }
         }
       }
@@ -3512,7 +3539,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c193();
+          s1 = peg$c194();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3542,27 +3569,27 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
-        s2 = peg$c194;
+        s2 = peg$c195;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c196); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c196) {
-          s2 = peg$c196;
+        if (input.substr(peg$currPos, 6) === peg$c197) {
+          s2 = peg$c197;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c198); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c198) {
-            s2 = peg$c198;
+          if (input.substr(peg$currPos, 3) === peg$c199) {
+            s2 = peg$c199;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c199); }
+            if (peg$silentFails === 0) { peg$fail(peg$c200); }
           }
         }
       }
@@ -3575,7 +3602,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c200();
+          s1 = peg$c201();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3605,27 +3632,27 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c201;
+        s2 = peg$c202;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c202); }
+        if (peg$silentFails === 0) { peg$fail(peg$c203); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c203) {
-          s2 = peg$c203;
+        if (input.substr(peg$currPos, 5) === peg$c204) {
+          s2 = peg$c204;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+          if (peg$silentFails === 0) { peg$fail(peg$c205); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 8) === peg$c205) {
-            s2 = peg$c205;
+          if (input.substr(peg$currPos, 8) === peg$c206) {
+            s2 = peg$c206;
             peg$currPos += 8;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c206); }
+            if (peg$silentFails === 0) { peg$fail(peg$c207); }
           }
         }
       }
@@ -3638,7 +3665,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c207();
+          s1 = peg$c208();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3660,124 +3687,124 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c208) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c209) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+      if (peg$silentFails === 0) { peg$fail(peg$c210); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c210) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c211) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c211); }
+        if (peg$silentFails === 0) { peg$fail(peg$c212); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c212) {
+        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c213) {
           s1 = input.substr(peg$currPos, 3);
           peg$currPos += 3;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c213); }
+          if (peg$silentFails === 0) { peg$fail(peg$c214); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c214) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c215) {
             s1 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c215); }
+            if (peg$silentFails === 0) { peg$fail(peg$c216); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c216) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c217) {
               s1 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c217); }
+              if (peg$silentFails === 0) { peg$fail(peg$c218); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3).toLowerCase() === peg$c218) {
+              if (input.substr(peg$currPos, 3).toLowerCase() === peg$c219) {
                 s1 = input.substr(peg$currPos, 3);
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c219); }
+                if (peg$silentFails === 0) { peg$fail(peg$c220); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c220) {
+                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c221) {
                   s1 = input.substr(peg$currPos, 3);
                   peg$currPos += 3;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c221); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c222); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c222) {
+                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c223) {
                     s1 = input.substr(peg$currPos, 3);
                     peg$currPos += 3;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c223); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c224); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c224) {
+                    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c225) {
                       s1 = input.substr(peg$currPos, 3);
                       peg$currPos += 3;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c226); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c226) {
+                      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c227) {
                         s1 = input.substr(peg$currPos, 3);
                         peg$currPos += 3;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c228); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
+                        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c229) {
                           s1 = input.substr(peg$currPos, 2);
                           peg$currPos += 2;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c230); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c230) {
+                          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c231) {
                             s1 = input.substr(peg$currPos, 2);
                             peg$currPos += 2;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c231); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c232); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
+                            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
                               s1 = input.substr(peg$currPos, 2);
                               peg$currPos += 2;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c233); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c234); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c234) {
+                              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c235) {
                                 s1 = input.substr(peg$currPos, 2);
                                 peg$currPos += 2;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c235); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c236); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c236) {
+                                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c237) {
                                   s1 = input.substr(peg$currPos, 2);
                                   peg$currPos += 2;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c238); }
                                 }
                               }
                             }
@@ -3795,7 +3822,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c238(s1);
+      s1 = peg$c239(s1);
     }
     s0 = s1;
 
@@ -3809,7 +3836,7 @@ function peg$parse(input, options) {
     s1 = peg$parsevariable();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c239(s1);
+      s1 = peg$c240(s1);
     }
     s0 = s1;
 
@@ -3819,44 +3846,44 @@ function peg$parse(input, options) {
   function peg$parsecommon_prefix() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c240) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c241) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+      if (peg$silentFails === 0) { peg$fail(peg$c242); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 1).toLowerCase() === peg$c242) {
+      if (input.substr(peg$currPos, 1).toLowerCase() === peg$c243) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c243); }
+        if (peg$silentFails === 0) { peg$fail(peg$c244); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c244) {
+        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
           s0 = input.substr(peg$currPos, 3);
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c245); }
+          if (peg$silentFails === 0) { peg$fail(peg$c246); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c246) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c247) {
             s0 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c247); }
+            if (peg$silentFails === 0) { peg$fail(peg$c248); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c248) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c249) {
               s0 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c250); }
             }
           }
         }
@@ -3869,12 +3896,12 @@ function peg$parse(input, options) {
   function peg$parseuppercase_letter() {
     var s0;
 
-    if (peg$c250.test(input.charAt(peg$currPos))) {
+    if (peg$c251.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c251); }
+      if (peg$silentFails === 0) { peg$fail(peg$c252); }
     }
 
     return s0;
@@ -3883,12 +3910,12 @@ function peg$parse(input, options) {
   function peg$parselowercase_letter() {
     var s0;
 
-    if (peg$c252.test(input.charAt(peg$currPos))) {
+    if (peg$c253.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c254); }
     }
 
     return s0;
@@ -3940,7 +3967,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c254(s1, s3);
+          s1 = peg$c255(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3964,12 +3991,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parsevariable();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c255) {
-        s2 = peg$c255;
+      if (input.substr(peg$currPos, 2) === peg$c256) {
+        s2 = peg$c256;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c256); }
+        if (peg$silentFails === 0) { peg$fail(peg$c257); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
@@ -3981,43 +4008,43 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 61) {
-            s4 = peg$c257;
+            s4 = peg$c258;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c258); }
+            if (peg$silentFails === 0) { peg$fail(peg$c259); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c259) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c260) {
               s4 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c260); }
+              if (peg$silentFails === 0) { peg$fail(peg$c261); }
             }
             if (s4 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c261) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c262) {
                 s4 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c262); }
+                if (peg$silentFails === 0) { peg$fail(peg$c263); }
               }
               if (s4 === peg$FAILED) {
-                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c263) {
+                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c264) {
                   s4 = input.substr(peg$currPos, 4);
                   peg$currPos += 4;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c264); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c265); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5).toLowerCase() === peg$c265) {
+                  if (input.substr(peg$currPos, 5).toLowerCase() === peg$c266) {
                     s4 = input.substr(peg$currPos, 5);
                     peg$currPos += 5;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c266); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c267); }
                   }
                 }
               }
@@ -4049,7 +4076,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c267(s1, s4);
+            s1 = peg$c268(s1, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4082,18 +4109,18 @@ function peg$parse(input, options) {
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c268) {
+          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c269) {
             s3 = input.substr(peg$currPos, 5);
             peg$currPos += 5;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c270); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsepoetic_string();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c267(s1, s4);
+              s1 = peg$c268(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4113,12 +4140,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c270) {
+        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c271) {
           s1 = input.substr(peg$currPos, 3);
           peg$currPos += 3;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c272); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -4145,12 +4172,12 @@ function peg$parse(input, options) {
                 s4 = peg$FAILED;
               }
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c272) {
+                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c273) {
                   s5 = input.substr(peg$currPos, 4);
                   peg$currPos += 4;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c273); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c274); }
                 }
                 if (s5 !== peg$FAILED) {
                   s6 = [];
@@ -4167,7 +4194,7 @@ function peg$parse(input, options) {
                     s7 = peg$parsevariable();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c274(s3, s7);
+                      s1 = peg$c275(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4209,21 +4236,21 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     s2 = [];
-    if (peg$c15.test(input.charAt(peg$currPos))) {
+    if (peg$c16.test(input.charAt(peg$currPos))) {
       s3 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+      if (peg$silentFails === 0) { peg$fail(peg$c17); }
     }
     while (s3 !== peg$FAILED) {
       s2.push(s3);
-      if (peg$c15.test(input.charAt(peg$currPos))) {
+      if (peg$c16.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c16); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -4233,7 +4260,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c275(s1);
+      s1 = peg$c276(s1);
     }
     s0 = s1;
 
@@ -4273,7 +4300,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c276(s2, s4);
+              s1 = peg$c277(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4304,11 +4331,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c114;
+      s1 = peg$c115;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      if (peg$silentFails === 0) { peg$fail(peg$c116); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -4328,7 +4355,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c277(s3);
+            s1 = peg$c278(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4349,11 +4376,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c114;
+        s1 = peg$c115;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -4383,12 +4410,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parse_();
     if (s0 === peg$FAILED) {
-      if (peg$c278.test(input.charAt(peg$currPos))) {
+      if (peg$c279.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c280); }
       }
     }
 
@@ -4422,7 +4449,7 @@ function peg$parse(input, options) {
           s4 = peg$parsepoetic_digits();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c280(s2, s4);
+            s1 = peg$c281(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4445,7 +4472,7 @@ function peg$parse(input, options) {
       s1 = peg$parsepoetic_digit();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281(s1);
+        s1 = peg$c282(s1);
       }
       s0 = s1;
     }
@@ -4461,11 +4488,11 @@ function peg$parse(input, options) {
       s0 = peg$parsepoetic_digit_separator();
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s0 = peg$c114;
+          s0 = peg$c115;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c116); }
         }
       }
     }
@@ -4500,7 +4527,7 @@ function peg$parse(input, options) {
           s4 = peg$parsepoetic_decimal_digits();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c280(s2, s4);
+            s1 = peg$c281(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4523,7 +4550,7 @@ function peg$parse(input, options) {
       s1 = peg$parsepoetic_digit();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281(s1);
+        s1 = peg$c282(s1);
       }
       s0 = s1;
     }
@@ -4536,22 +4563,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c282.test(input.charAt(peg$currPos))) {
+    if (peg$c283.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c282.test(input.charAt(peg$currPos))) {
+        if (peg$c283.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c284); }
         }
       }
     } else {
@@ -4559,7 +4586,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c284(s1);
+      s1 = peg$c285(s1);
     }
     s0 = s1;
 
@@ -4583,12 +4610,12 @@ function peg$parse(input, options) {
   function peg$parsekw10() {
     var s0;
 
-    if (input.substr(peg$currPos, 10).toLowerCase() === peg$c107) {
+    if (input.substr(peg$currPos, 10).toLowerCase() === peg$c108) {
       s0 = input.substr(peg$currPos, 10);
       peg$currPos += 10;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
 
     return s0;
@@ -4597,20 +4624,20 @@ function peg$parse(input, options) {
   function peg$parsekw8() {
     var s0;
 
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c148) {
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c149) {
       s0 = input.substr(peg$currPos, 8);
       peg$currPos += 8;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c149); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 8).toLowerCase() === peg$c20) {
+      if (input.substr(peg$currPos, 8).toLowerCase() === peg$c21) {
         s0 = input.substr(peg$currPos, 8);
         peg$currPos += 8;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
       }
     }
 
@@ -4620,60 +4647,60 @@ function peg$parse(input, options) {
   function peg$parsekw7() {
     var s0;
 
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c286) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c287) {
       s0 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c287); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c144) {
+      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c145) {
         s0 = input.substr(peg$currPos, 7);
         peg$currPos += 7;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c145); }
+        if (peg$silentFails === 0) { peg$fail(peg$c146); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c96) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c97) {
           s0 = input.substr(peg$currPos, 7);
           peg$currPos += 7;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c97); }
+          if (peg$silentFails === 0) { peg$fail(peg$c98); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7).toLowerCase() === peg$c98) {
+          if (input.substr(peg$currPos, 7).toLowerCase() === peg$c99) {
             s0 = input.substr(peg$currPos, 7);
             peg$currPos += 7;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+            if (peg$silentFails === 0) { peg$fail(peg$c100); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 7).toLowerCase() === peg$c154) {
+            if (input.substr(peg$currPos, 7).toLowerCase() === peg$c155) {
               s0 = input.substr(peg$currPos, 7);
               peg$currPos += 7;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c155); }
+              if (peg$silentFails === 0) { peg$fail(peg$c156); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c71) {
+              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c72) {
                 s0 = input.substr(peg$currPos, 7);
                 peg$currPos += 7;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c72); }
+                if (peg$silentFails === 0) { peg$fail(peg$c73); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 7).toLowerCase() === peg$c288) {
+                if (input.substr(peg$currPos, 7).toLowerCase() === peg$c289) {
                   s0 = input.substr(peg$currPos, 7);
                   peg$currPos += 7;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c290); }
                 }
               }
             }
@@ -4688,84 +4715,84 @@ function peg$parse(input, options) {
   function peg$parsekw6() {
     var s0;
 
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c132) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c133) {
       s0 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c133); }
+      if (peg$silentFails === 0) { peg$fail(peg$c134); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c146) {
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
         s0 = input.substr(peg$currPos, 6);
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c147); }
+        if (peg$silentFails === 0) { peg$fail(peg$c148); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c51) {
+        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c52) {
           s0 = input.substr(peg$currPos, 6);
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c52); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c100) {
+          if (input.substr(peg$currPos, 6).toLowerCase() === peg$c101) {
             s0 = input.substr(peg$currPos, 6);
             peg$currPos += 6;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c102); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6).toLowerCase() === peg$c43) {
+            if (input.substr(peg$currPos, 6).toLowerCase() === peg$c44) {
               s0 = input.substr(peg$currPos, 6);
               peg$currPos += 6;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+              if (peg$silentFails === 0) { peg$fail(peg$c45); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6).toLowerCase() === peg$c73) {
+              if (input.substr(peg$currPos, 6).toLowerCase() === peg$c74) {
                 s0 = input.substr(peg$currPos, 6);
                 peg$currPos += 6;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c75); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 6).toLowerCase() === peg$c40) {
+                if (input.substr(peg$currPos, 6).toLowerCase() === peg$c41) {
                   s0 = input.substr(peg$currPos, 6);
                   peg$currPos += 6;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c42); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 6).toLowerCase() === peg$c156) {
+                  if (input.substr(peg$currPos, 6).toLowerCase() === peg$c157) {
                     s0 = input.substr(peg$currPos, 6);
                     peg$currPos += 6;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c157); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c158); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c142) {
+                    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c143) {
                       s0 = input.substr(peg$currPos, 6);
                       peg$currPos += 6;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c144); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c164) {
+                      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c165) {
                         s0 = input.substr(peg$currPos, 6);
                         peg$currPos += 6;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c165); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c166); }
                       }
                     }
                   }
@@ -4783,140 +4810,140 @@ function peg$parse(input, options) {
   function peg$parsekw5() {
     var s0;
 
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c17) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c18) {
       s0 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c18); }
+      if (peg$silentFails === 0) { peg$fail(peg$c19); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c290) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c291) {
         s0 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c291); }
+        if (peg$silentFails === 0) { peg$fail(peg$c292); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c102) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c103) {
           s0 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c103); }
+          if (peg$silentFails === 0) { peg$fail(peg$c104); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c85) {
+          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c86) {
             s0 = input.substr(peg$currPos, 5);
             peg$currPos += 5;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c86); }
+            if (peg$silentFails === 0) { peg$fail(peg$c87); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c160) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c161) {
               s0 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c161); }
+              if (peg$silentFails === 0) { peg$fail(peg$c162); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5).toLowerCase() === peg$c292) {
+              if (input.substr(peg$currPos, 5).toLowerCase() === peg$c293) {
                 s0 = input.substr(peg$currPos, 5);
                 peg$currPos += 5;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                if (peg$silentFails === 0) { peg$fail(peg$c294); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5).toLowerCase() === peg$c150) {
+                if (input.substr(peg$currPos, 5).toLowerCase() === peg$c151) {
                   s0 = input.substr(peg$currPos, 5);
                   peg$currPos += 5;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c151); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c152); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5).toLowerCase() === peg$c80) {
+                  if (input.substr(peg$currPos, 5).toLowerCase() === peg$c81) {
                     s0 = input.substr(peg$currPos, 5);
                     peg$currPos += 5;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c81); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c82); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c69) {
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c70) {
                       s0 = input.substr(peg$currPos, 5);
                       peg$currPos += 5;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c70); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c71); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c168) {
+                      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c169) {
                         s0 = input.substr(peg$currPos, 5);
                         peg$currPos += 5;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c169); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c170); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c294) {
+                        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c295) {
                           s0 = input.substr(peg$currPos, 5);
                           peg$currPos += 5;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c295); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c296); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c25) {
+                          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c26) {
                             s0 = input.substr(peg$currPos, 5);
                             peg$currPos += 5;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c26); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c27); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c296) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c297) {
                               s0 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c297); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c298); }
                             }
                             if (s0 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5).toLowerCase() === peg$c64) {
+                              if (input.substr(peg$currPos, 5).toLowerCase() === peg$c65) {
                                 s0 = input.substr(peg$currPos, 5);
                                 peg$currPos += 5;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c65); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c66); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+                                if (input.substr(peg$currPos, 5).toLowerCase() === peg$c62) {
                                   s0 = input.substr(peg$currPos, 5);
                                   peg$currPos += 5;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c63); }
                                 }
                                 if (s0 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5).toLowerCase() === peg$c89) {
+                                  if (input.substr(peg$currPos, 5).toLowerCase() === peg$c90) {
                                     s0 = input.substr(peg$currPos, 5);
                                     peg$currPos += 5;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c90); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c91); }
                                   }
                                   if (s0 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c298) {
+                                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c299) {
                                       s0 = input.substr(peg$currPos, 5);
                                       peg$currPos += 5;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c300); }
                                     }
                                   }
                                 }
@@ -4941,180 +4968,180 @@ function peg$parse(input, options) {
   function peg$parsekw4() {
     var s0;
 
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c131) {
       s0 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
+      if (peg$silentFails === 0) { peg$fail(peg$c132); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c300) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c301) {
         s0 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c302); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c302) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c303) {
           s0 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          if (peg$silentFails === 0) { peg$fail(peg$c304); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c55) {
+          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c56) {
             s0 = input.substr(peg$currPos, 4);
             peg$currPos += 4;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c56); }
+            if (peg$silentFails === 0) { peg$fail(peg$c57); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c304) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c305) {
               s0 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c104) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c105) {
                 s0 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                if (peg$silentFails === 0) { peg$fail(peg$c106); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c158) {
+                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c159) {
                   s0 = input.substr(peg$currPos, 4);
                   peg$currPos += 4;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c159); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c160); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 4).toLowerCase() === peg$c272) {
+                  if (input.substr(peg$currPos, 4).toLowerCase() === peg$c273) {
                     s0 = input.substr(peg$currPos, 4);
                     peg$currPos += 4;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c273); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c274); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c152) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
                       s0 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c153); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c154); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
+                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c88) {
                         s0 = input.substr(peg$currPos, 4);
                         peg$currPos += 4;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c88); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c89); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c94) {
+                        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c95) {
                           s0 = input.substr(peg$currPos, 4);
                           peg$currPos += 4;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c95); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c96); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c306) {
+                          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c307) {
                             s0 = input.substr(peg$currPos, 4);
                             peg$currPos += 4;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c307); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c308); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c308) {
+                            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c309) {
                               s0 = input.substr(peg$currPos, 4);
                               peg$currPos += 4;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c310); }
                             }
                             if (s0 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c173) {
                                 s0 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c173); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c174); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c210) {
+                                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c211) {
                                   s0 = input.substr(peg$currPos, 4);
                                   peg$currPos += 4;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c211); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c212); }
                                 }
                                 if (s0 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 4).toLowerCase() === peg$c208) {
+                                  if (input.substr(peg$currPos, 4).toLowerCase() === peg$c209) {
                                     s0 = input.substr(peg$currPos, 4);
                                     peg$currPos += 4;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c209); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c210); }
                                   }
                                   if (s0 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c76) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c77) {
                                       s0 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c77); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c78); }
                                     }
                                     if (s0 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c170) {
+                                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c171) {
                                         s0 = input.substr(peg$currPos, 4);
                                         peg$currPos += 4;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c172); }
                                       }
                                       if (s0 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c310) {
+                                        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c311) {
                                           s0 = input.substr(peg$currPos, 4);
                                           peg$currPos += 4;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c311); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c312); }
                                         }
                                         if (s0 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c248) {
+                                          if (input.substr(peg$currPos, 4).toLowerCase() === peg$c249) {
                                             s0 = input.substr(peg$currPos, 4);
                                             peg$currPos += 4;
                                           } else {
                                             s0 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c249); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c250); }
                                           }
                                           if (s0 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c312) {
+                                            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c313) {
                                               s0 = input.substr(peg$currPos, 4);
                                               peg$currPos += 4;
                                             } else {
                                               s0 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c314); }
                                             }
                                             if (s0 === peg$FAILED) {
-                                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c314) {
+                                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c315) {
                                                 s0 = input.substr(peg$currPos, 4);
                                                 peg$currPos += 4;
                                               } else {
                                                 s0 = peg$FAILED;
-                                                if (peg$silentFails === 0) { peg$fail(peg$c315); }
+                                                if (peg$silentFails === 0) { peg$fail(peg$c316); }
                                               }
                                             }
                                           }
@@ -5144,164 +5171,164 @@ function peg$parse(input, options) {
   function peg$parsekw3() {
     var s0;
 
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c30) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c31) {
       s0 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c317); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c162) {
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c163) {
         s0 = input.substr(peg$currPos, 3);
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c216) {
+        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c217) {
           s0 = input.substr(peg$currPos, 3);
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c217); }
+          if (peg$silentFails === 0) { peg$fail(peg$c218); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c214) {
+          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c215) {
             s0 = input.substr(peg$currPos, 3);
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c215); }
+            if (peg$silentFails === 0) { peg$fail(peg$c216); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c218) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c219) {
               s0 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c219); }
+              if (peg$silentFails === 0) { peg$fail(peg$c220); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3).toLowerCase() === peg$c317) {
+              if (input.substr(peg$currPos, 3).toLowerCase() === peg$c318) {
                 s0 = input.substr(peg$currPos, 3);
                 peg$currPos += 3;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c318); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c166) {
+                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c167) {
                   s0 = input.substr(peg$currPos, 3);
                   peg$currPos += 3;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c167); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c168); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c123) {
+                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c124) {
                     s0 = input.substr(peg$currPos, 3);
                     peg$currPos += 3;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c320); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c139) {
+                    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c140) {
                       s0 = input.substr(peg$currPos, 3);
                       peg$currPos += 3;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c321); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c270) {
+                      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c271) {
                         s0 = input.substr(peg$currPos, 3);
                         peg$currPos += 3;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c272); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c67) {
+                        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c68) {
                           s0 = input.substr(peg$currPos, 3);
                           peg$currPos += 3;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c68); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c69); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c212) {
+                          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c213) {
                             s0 = input.substr(peg$currPos, 3);
                             peg$currPos += 3;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c213); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c214); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c244) {
+                            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c245) {
                               s0 = input.substr(peg$currPos, 3);
                               peg$currPos += 3;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c245); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c246); }
                             }
                             if (s0 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 3).toLowerCase() === peg$c321) {
+                              if (input.substr(peg$currPos, 3).toLowerCase() === peg$c322) {
                                 s0 = input.substr(peg$currPos, 3);
                                 peg$currPos += 3;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c322); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c323); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c226) {
+                                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c227) {
                                   s0 = input.substr(peg$currPos, 3);
                                   peg$currPos += 3;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c227); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c228); }
                                 }
                                 if (s0 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c323) {
+                                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c324) {
                                     s0 = input.substr(peg$currPos, 3);
                                     peg$currPos += 3;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c325); }
                                   }
                                   if (s0 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c224) {
+                                    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c225) {
                                       s0 = input.substr(peg$currPos, 3);
                                       peg$currPos += 3;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c226); }
                                     }
                                     if (s0 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c82) {
+                                      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c83) {
                                         s0 = input.substr(peg$currPos, 3);
                                         peg$currPos += 3;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c84); }
                                       }
                                       if (s0 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c220) {
+                                        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c221) {
                                           s0 = input.substr(peg$currPos, 3);
                                           peg$currPos += 3;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c221); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c222); }
                                         }
                                         if (s0 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c222) {
+                                          if (input.substr(peg$currPos, 3).toLowerCase() === peg$c223) {
                                             s0 = input.substr(peg$currPos, 3);
                                             peg$currPos += 3;
                                           } else {
                                             s0 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c223); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c224); }
                                           }
                                         }
                                       }
@@ -5329,132 +5356,132 @@ function peg$parse(input, options) {
   function peg$parsekw2() {
     var s0;
 
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c240) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c241) {
       s0 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+      if (peg$silentFails === 0) { peg$fail(peg$c242); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c176) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c177) {
         s0 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c177); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c236) {
+        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c237) {
           s0 = input.substr(peg$currPos, 2);
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c237); }
+          if (peg$silentFails === 0) { peg$fail(peg$c238); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c59) {
             s0 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c59); }
+            if (peg$silentFails === 0) { peg$fail(peg$c60); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c135) {
+            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c136) {
               s0 = input.substr(peg$currPos, 2);
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c136); }
+              if (peg$silentFails === 0) { peg$fail(peg$c137); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c234) {
+              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c235) {
                 s0 = input.substr(peg$currPos, 2);
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c235); }
+                if (peg$silentFails === 0) { peg$fail(peg$c236); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c246) {
+                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c247) {
                   s0 = input.substr(peg$currPos, 2);
                   peg$currPos += 2;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c248); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2).toLowerCase() === peg$c91) {
+                  if (input.substr(peg$currPos, 2).toLowerCase() === peg$c92) {
                     s0 = input.substr(peg$currPos, 2);
                     peg$currPos += 2;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c92); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c93); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c325) {
+                    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c326) {
                       s0 = input.substr(peg$currPos, 2);
                       peg$currPos += 2;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c326); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c327); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c78) {
+                      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c79) {
                         s0 = input.substr(peg$currPos, 2);
                         peg$currPos += 2;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c80); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c126) {
+                        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c127) {
                           s0 = input.substr(peg$currPos, 2);
                           peg$currPos += 2;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c327); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c328); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c328) {
+                          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c329) {
                             s0 = input.substr(peg$currPos, 2);
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c330); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c330) {
+                            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c331) {
                               s0 = input.substr(peg$currPos, 2);
                               peg$currPos += 2;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c331); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c332); }
                             }
                             if (s0 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c230) {
+                              if (input.substr(peg$currPos, 2).toLowerCase() === peg$c231) {
                                 s0 = input.substr(peg$currPos, 2);
                                 peg$currPos += 2;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c231); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c232); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
+                                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
                                   s0 = input.substr(peg$currPos, 2);
                                   peg$currPos += 2;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c233); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
                                 }
                                 if (s0 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
+                                  if (input.substr(peg$currPos, 2).toLowerCase() === peg$c229) {
                                     s0 = input.substr(peg$currPos, 2);
                                     peg$currPos += 2;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c230); }
                                   }
                                 }
                               }
@@ -5478,12 +5505,12 @@ function peg$parse(input, options) {
   function peg$parsekw1() {
     var s0;
 
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c242) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c243) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c243); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
 
     return s0;
@@ -5600,11 +5627,11 @@ function peg$parse(input, options) {
       s4 = [];
       s5 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 32) {
-        s6 = peg$c332;
+        s6 = peg$c333;
         peg$currPos++;
       } else {
         s6 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c334); }
       }
       if (s6 !== peg$FAILED) {
         s7 = peg$currPos;
@@ -5629,11 +5656,11 @@ function peg$parse(input, options) {
         s4.push(s5);
         s5 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 32) {
-          s6 = peg$c332;
+          s6 = peg$c333;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c333); }
+          if (peg$silentFails === 0) { peg$fail(peg$c334); }
         }
         if (s6 !== peg$FAILED) {
           s7 = peg$currPos;
@@ -5673,7 +5700,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c334(s1);
+      s1 = peg$c335(s1);
     }
     s0 = s1;
 
@@ -5695,12 +5722,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c290) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c291) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5711,12 +5738,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = [];
             s6 = peg$currPos;
-            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c330) {
+            if (input.substr(peg$currPos, 2).toLowerCase() === peg$c331) {
               s7 = input.substr(peg$currPos, 2);
               peg$currPos += 2;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c331); }
+              if (peg$silentFails === 0) { peg$fail(peg$c332); }
             }
             if (s7 !== peg$FAILED) {
               s8 = [];
@@ -5740,12 +5767,12 @@ function peg$parse(input, options) {
               while (s6 !== peg$FAILED) {
                 s5.push(s6);
                 s6 = peg$currPos;
-                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c330) {
+                if (input.substr(peg$currPos, 2).toLowerCase() === peg$c331) {
                   s7 = input.substr(peg$currPos, 2);
                   peg$currPos += 2;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c331); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c332); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = [];
@@ -5771,7 +5798,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c335(s3, s5);
+              s1 = peg$c336(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5801,12 +5828,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c292) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c293) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c293); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5817,12 +5844,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = [];
             s6 = peg$currPos;
-            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c302) {
+            if (input.substr(peg$currPos, 4).toLowerCase() === peg$c303) {
               s7 = input.substr(peg$currPos, 4);
               peg$currPos += 4;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c303); }
+              if (peg$silentFails === 0) { peg$fail(peg$c304); }
             }
             if (s7 !== peg$FAILED) {
               s8 = [];
@@ -5846,12 +5873,12 @@ function peg$parse(input, options) {
               while (s6 !== peg$FAILED) {
                 s5.push(s6);
                 s6 = peg$currPos;
-                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c302) {
+                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c303) {
                   s7 = input.substr(peg$currPos, 4);
                   peg$currPos += 4;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c304); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = [];
@@ -5877,7 +5904,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c336(s3, s5);
+              s1 = peg$c337(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;


### PR DESCRIPTION
No new tests added as `tests/fixtures/whitespace/no_newline_at_eof.rock` already covers this case