### PR TITLE
Mutations supporting cast, split and join

### DIFF
--- a/satriani/package.json
+++ b/satriani/package.json
@@ -20,7 +20,7 @@
     "browserify": "node node_modules/browserify/bin/cmd.js satriani.js --standalone Satriani -o deploy/docs/js/satriani.js",
     "deploy": "node_modules/gh-pages/bin/gh-pages.js -u 'CircleCI <circleci@codewithrockstar.com>' -r git@github.com:RockstarLang/codewithrockstar.com.git --add --src docs/js/satriani.js -m 'Updated js/satriani.js from main repo' -b master -d deploy",
     "serve": "python -m SimpleHTTPServer 8000",
-    "pegjs": "node node_modules/pegjs/bin/pegjs -o satriani.parser.js rockstar.peg",
+    "pegjs": "node node_modules/pegjs/bin/pegjs --cache -o satriani.parser.js rockstar.peg",
     "test": "yarn pegjs && mocha test/*.js"
   },
   "repository": {

--- a/satriani/rockstar.peg
+++ b/satriani/rockstar.peg
@@ -12,8 +12,8 @@ After updating, run pegjs -o rockstar-parser.js rockstar.peg
     'between','greater','nothing','nowhere','smaller','whisper','without',
     'ain\'t','around','bigger','listen','nobody','return','scream','taking','weaker','higher', 'strong',
     'break','build','empty','false','great','knock','lower','right','round','shout', 
-    'small','take','takes','times','until','while','wrong','minus',
-    'aint','back','down','else','give','gone','high','into','less','lies','null','plus','says','than','them','they','true','weak','were','your','over','with',
+    'small','take','takes','times','until','unite','while','wrong','minus',
+    'aint','back','cast','burn','join','down','else','give','gone','high','into','less','lies','null','plus','says','than','them','they','true','weak','were','your','over','with',
     'and','big','her','him','hir','it ','low','nor','not','put','say','she','the','top','ver','was','xem','yes','zie','zir',
     'an','as','at','he','if','is','it','my','no','of','ok','or','to','up','ve', 'xe','ze',
     'a'
@@ -79,7 +79,7 @@ return = 'return'i / 'give back'i
 function_return = return _ e:expression
 	{ return { 'return': { 'expression' : e } } }
 
-operation = readline / output / crement / string_split / assignment / rounding
+operation = readline / output / crement / mutation / assignment / rounding
 
 readline
   = 'listen to'i _ target:assignable
@@ -276,13 +276,12 @@ common_variable = prefix:common_prefix _+ name:$(letter+)
 
 is = ('\'s' / (_* ('=' / 'is 'i / 'was 'i / 'are 'i / 'were 'i)))
 
-into_target = _ 'into'i _ t:assignable { return t }
+target = _ 'into'i _ t:assignable { return t }
 
+indexer = _ 'at'i _ i:expression { return i };
 assignable
-  = v:variable _ 'at'i _ i:expression
+  = v:variable i:indexer?
     { return { variable: v, index: i }; }
-  / v:variable
-    { return { variable: v }; }
 
 assignment = target:assignable is _* e:(literal / poetic_number)
     { return { assign: { target: target, expression: e} }; }
@@ -290,7 +289,7 @@ assignment = target:assignable is _* e:(literal / poetic_number)
   / target:assignable _+ 'says 'i e:poetic_string
     { return { assign: { target: target, expression: e} }; }
 
-  / 'put'i _+ e:expression target:into_target
+  / 'put'i _+ e:expression target:target
     { return { assign: { target: target, expression: e} }; }
 
   / 'let'i _+ target:assignable _+ 'be'i o:compoundable_operator e:expression {
@@ -303,17 +302,6 @@ assignment = target:assignable is _* e:(literal / poetic_number)
   / 'let'i _+ target:assignable _+ 'be'i _+ e:expression
     { return { assign: { target: target, expression: e} }; }
 
-split = 'cut'i / 'split'i / 'shatter'i
-
-string_split
-	= split _ s:assignable _ 'with'i _ d:expression
-     { return { assign: { target: s, expression: { split: { source: { lookup: s }, delimiter: d } } } } ; }
-	/ split _ s:expression t:into_target _ 'with'i _ d:expression
-     { return { assign: { target: t, expression: { split: { source: s, delimiter: d } } } } ; }
-	/ split _ s:expression t:into_target
-     { return { assign: { target: t, expression: { split: { source: s } } } } ; }
-	/ split _ s:assignable
-     { return { assign: { target: s, expression: { split: { source: { lookup: s } } } } } ; }
 
 poetic_string = s:$[^\n]*
   { return { string: s} }
@@ -372,6 +360,20 @@ decrement = 'knock'i _ v:variable _ t:('down'i noise*)+
             multiple: t.length
         }
     }; }
+
+
+split = ('cut'i / 'split'i / 'shatter'i) { return 'split' }
+cast = ('cast'i / 'burn'i) { return 'cast' }
+join = ('join'i / 'unite'i) { return 'join' }
+
+mutator = split / cast / join
+modifier =  _ ('with'i / 'using'i) _ m:expression { return m }
+
+mutation
+    = op:mutator _ s:expression t:target m:modifier?
+        { return { assign: { target: t, expression: { mutation: { type: op, source: s, modifier: m } } } } ; }
+	/ op:mutator _ s:assignable m:modifier?
+        { return { assign: { target: s, expression: { mutation: { type: op, source: { lookup: s }, modifier: m } } } } ; }
 
 rounding = floor / ceil / math_round
 

--- a/satriani/satriani.parser.cache.js
+++ b/satriani/satriani.parser.cache.js
@@ -539,21 +539,19 @@ function peg$parse(input, options) {
       peg$c331 = function() { return 'join' },
       peg$c332 = "with",
       peg$c333 = peg$literalExpectation("with", true),
-      peg$c334 = "using",
-      peg$c335 = peg$literalExpectation("using", true),
-      peg$c336 = function(m) { return m },
-      peg$c337 = function(op, s, t, m) { return { assign: { target: t, expression: { mutation: { type: op, source: s, modifier: m } } } } ; },
-      peg$c338 = function(op, s, m) { return { assign: { target: s, expression: { mutation: { type: op, source: { lookup: s }, modifier: m } } } } ; },
-      peg$c339 = "turn",
-      peg$c340 = peg$literalExpectation("turn", true),
-      peg$c341 = function(v) { return { rounding: { variable: v, direction: 'down'  } }; },
-      peg$c342 = function(v) { return { rounding: { variable: v, direction: 'up'  } }; },
-      peg$c343 = function(v) { return { rounding: { variable: v, direction: 'up' } }; },
-      peg$c344 = "round",
-      peg$c345 = peg$literalExpectation("round", true),
-      peg$c346 = "around",
-      peg$c347 = peg$literalExpectation("around", true),
-      peg$c348 = function(v) { return { rounding: { variable: v, direction: 'nearest' } }; },
+      peg$c334 = function(m) { return m },
+      peg$c335 = function(op, s, m) { return { assign: { target: s, expression: { mutation: { type: op, source: { lookup: s }, modifier: m } } } } ; },
+      peg$c336 = function(op, s, t, m) { return { assign: { target: t, expression: { mutation: { type: op, source: s, modifier: m } } } } ; },
+      peg$c337 = "turn",
+      peg$c338 = peg$literalExpectation("turn", true),
+      peg$c339 = function(v) { return { rounding: { variable: v, direction: 'down'  } }; },
+      peg$c340 = function(v) { return { rounding: { variable: v, direction: 'up'  } }; },
+      peg$c341 = function(v) { return { rounding: { variable: v, direction: 'up' } }; },
+      peg$c342 = "round",
+      peg$c343 = peg$literalExpectation("round", true),
+      peg$c344 = "around",
+      peg$c345 = peg$literalExpectation("around", true),
+      peg$c346 = function(v) { return { rounding: { variable: v, direction: 'nearest' } }; },
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -6412,22 +6410,13 @@ function peg$parse(input, options) {
         s2 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c333); }
       }
-      if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c334) {
-          s2 = input.substr(peg$currPos, 5);
-          peg$currPos += 5;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c335); }
-        }
-      }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           s4 = peg$parsenor();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c336(s4);
+            s1 = peg$c334(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6468,22 +6457,16 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsenor();
+        s3 = peg$parseassignable();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parsetarget();
+          s4 = peg$parsemodifier();
+          if (s4 === peg$FAILED) {
+            s4 = null;
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsemodifier();
-            if (s5 === peg$FAILED) {
-              s5 = null;
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c337(s1, s3, s4, s5);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
+            peg$savedPos = s0;
+            s1 = peg$c335(s1, s3, s4);
+            s0 = s1;
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -6506,16 +6489,22 @@ function peg$parse(input, options) {
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseassignable();
+          s3 = peg$parsenor();
           if (s3 !== peg$FAILED) {
-            s4 = peg$parsemodifier();
-            if (s4 === peg$FAILED) {
-              s4 = null;
-            }
+            s4 = peg$parsetarget();
             if (s4 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c338(s1, s3, s4);
-              s0 = s1;
+              s5 = peg$parsemodifier();
+              if (s5 === peg$FAILED) {
+                s5 = null;
+              }
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c336(s1, s3, s4, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -6577,12 +6566,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c337) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6600,7 +6589,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c341(s3);
+              s1 = peg$c339(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6624,12 +6613,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c339) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c337) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c340); }
+        if (peg$silentFails === 0) { peg$fail(peg$c338); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6647,7 +6636,7 @@ function peg$parse(input, options) {
               s5 = peg$parsevariable();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c341(s5);
+                s1 = peg$c339(s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6689,12 +6678,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c337) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6712,7 +6701,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c342(s3);
+              s1 = peg$c340(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6736,12 +6725,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c339) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c337) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c340); }
+        if (peg$silentFails === 0) { peg$fail(peg$c338); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6759,7 +6748,7 @@ function peg$parse(input, options) {
               s5 = peg$parsevariable();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c343(s5);
+                s1 = peg$c341(s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6801,12 +6790,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c337) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6815,25 +6804,25 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c344) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c342) {
               s5 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c345); }
+              if (peg$silentFails === 0) { peg$fail(peg$c343); }
             }
             if (s5 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6).toLowerCase() === peg$c346) {
+              if (input.substr(peg$currPos, 6).toLowerCase() === peg$c344) {
                 s5 = input.substr(peg$currPos, 6);
                 peg$currPos += 6;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c347); }
+                if (peg$silentFails === 0) { peg$fail(peg$c345); }
               }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c348(s3);
+              s1 = peg$c346(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6857,30 +6846,30 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c339) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c337) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c340); }
+        if (peg$silentFails === 0) { peg$fail(peg$c338); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c344) {
+          if (input.substr(peg$currPos, 5).toLowerCase() === peg$c342) {
             s3 = input.substr(peg$currPos, 5);
             peg$currPos += 5;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c345); }
+            if (peg$silentFails === 0) { peg$fail(peg$c343); }
           }
           if (s3 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6).toLowerCase() === peg$c346) {
+            if (input.substr(peg$currPos, 6).toLowerCase() === peg$c344) {
               s3 = input.substr(peg$currPos, 6);
               peg$currPos += 6;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c347); }
+              if (peg$silentFails === 0) { peg$fail(peg$c345); }
             }
           }
           if (s3 !== peg$FAILED) {
@@ -6889,7 +6878,7 @@ function peg$parse(input, options) {
               s5 = peg$parsevariable();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c348(s5);
+                s1 = peg$c346(s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;

--- a/spec.md
+++ b/spec.md
@@ -117,9 +117,24 @@ Shout my string at 1 (will print "b")
 Let the character be my string at 2
 ```
 
-### Splitting strings
+### Splitting strings and type conversions
 
-To split a string in Rockstar, use the `cut` keyword (aliases `split` and `shatter`)
+#### A note about mutations
+
+Some operations in Rockstar will either act in-place, modifying the variable passed to them, or will leave the
+source variable unmodified and place their output into a target variable. These operations are known as mutation 
+operations, and they all have the syntax
+
+* `Modify X` - acts in-place 
+* `Modify X into Y` - leave `X` alone and put modified output into `Y`
+* `Modify X with Z` - modify `X` in-place, with optional parameter `Z`
+* `Modify X into Y with Z` - modify `X`, using parameter `Y`, and put results in `Z`
+
+Note that in-place mutations are **only valid where the first argument is a variable**:
+
+#### Splitting Strings
+
+To split a string in Rockstar, use the `cut` mutation (aliases `split` and `shatter`)
 
 String splitting can either operate in-place, or place results into an output variable.
 You can specify an optional delimiter; if no delimiter is provided, the string is split
@@ -147,6 +162,45 @@ following would be invalid (because where would the result actually go?)
 ```$
 Split "a,b,c,d,e" with "," (NOT VALID - nowhere to place the output)
 Split "a,b,c,d,e" into tokens with "," (valid - tokens now contains ["a","b","c","d","e"])
+```
+
+#### Joining Arrays
+
+To join an array in Rockstar, use the `join` mutation, or the alias `unite`
+
+```
+Let the string be "abcde"
+Split the string into tokens
+Join tokens with ";"
+    (the tokens now contains "a;b;c;d;e")
+
+The input says hey now hey now now
+Split the input into words with " "
+Unite words into the output with "! "
+    (the output now contains "hey! now! hey! now! now!")
+```
+
+#### Parsing numbers and character codes
+
+Use the `cast` mutation to parse strings into numbers, or to convert numbers into their corresponding Unicode characters.
+
+```$rockstar
+Let X be "123.45"
+Cast X
+    (X now contains the numeric value 123.45)
+Let X be "ff"
+Cast X with 16
+    (X now contains the numeric value 255 - OxFF)
+Cast "12345" into result
+    (result now contains the number 12345)
+Cast "aa" into result with 16
+    (result now contains the number 170 - 0xAA)
+
+Cast 65 into result
+    (result now contains the string "A" - ASCII code 65)
+
+Cast 1046 into result
+    (result now contains the Cyrillic letter "Ж" - Unicode code point 1046)
 ```
 
 ### Truthiness

--- a/tests/fixtures/arrays/join.rock
+++ b/tests/fixtures/arrays/join.rock
@@ -1,0 +1,15 @@
+Let the array at 0 be "a"
+Let the array at 1 be "b"
+Let the array at 2 be "c"
+Join the array into ResultA
+Shout ResultA
+
+Join the array into ResultB with "-"
+Shout ResultB
+
+Join the array
+Shout the array
+
+Split "abcde" into tokens
+Join tokens with ";"
+Shout tokens

--- a/tests/fixtures/arrays/join.rock.out
+++ b/tests/fixtures/arrays/join.rock.out
@@ -1,0 +1,4 @@
+abc
+a-b-c
+abc
+a;b;c;d;e

--- a/tests/fixtures/types/parsing.rock
+++ b/tests/fixtures/types/parsing.rock
@@ -1,0 +1,14 @@
+Say "parsing ints with cast"
+Let X be "123"
+Let Y be "456"
+Let Z be X with Y
+Shout Z (123456)
+Cast X
+Cast Y
+Let Z be X with Y
+Shout Z (579)
+
+Say "creating chars with cast"
+Let X be 65
+Cast X
+Shout X (A)

--- a/tests/fixtures/types/parsing.rock.out
+++ b/tests/fixtures/types/parsing.rock.out
@@ -1,0 +1,5 @@
+parsing ints with cast
+123456
+579
+creating chars with cast
+A

--- a/tools/example.rock
+++ b/tools/example.rock
@@ -1,6 +1,5 @@
-Cut your life
-Cut my life into pieces
-Cut your cake with my knife
-Cut "a,b,c" with ","
-Cut "time tells no lies" into tokens with " "
+Cast X
+Cast X with Y
+Cast X into Z
+Cast X into Z with Q
 


### PR DESCRIPTION
Adds support for:

* `cast` keyword (integer parsing and character code conversion)
* `join` keyword (joining arrays)

Also cleans up existing array split code, and enables caching on the pegJS parser generator which has massively improved parser performance.