### PR TITLE
Explicitly convert array to scalar

### DIFF
--- a/satriani/satriani.interpreter.js
+++ b/satriani/satriani.interpreter.js
@@ -174,21 +174,21 @@ function evaluate(tree, env) {
                 }
                 return;
             case "comparison":
-                let lhs = toScalar(evaluate(expr.lhs, env));
-                let rhs = toScalar(evaluate(expr.rhs, env));
+                let lhs = evaluate(expr.lhs, env);
+                let rhs = evaluate(expr.rhs, env);
                 switch (expr.comparator) {
                     case "eq":
                         return eq(lhs, rhs);
                     case "ne":
                         return !eq(lhs, rhs);
                     case "lt":
-                        return (lhs < rhs);
+                        return (toScalar(lhs) < toScalar(rhs));
                     case "le":
-                        return (lhs <= rhs);
+                        return (toScalar(lhs) <= toScalar(rhs));
                     case "ge":
-                        return (lhs >= rhs);
+                        return (toScalar(lhs) >= toScalar(rhs));
                     case "gt":
-                        return (lhs > rhs);
+                        return (toScalar(lhs) > toScalar(rhs));
                     default:
                         throw new Error(`Unknown comparison operator ${expr.comparator}`);
                 }
@@ -356,7 +356,7 @@ function is_nothing(thing) {
 }
 
 function eq_array(array, other) {
-    if (Array.isArray(other)) return ((array.length == other.length) && array.every((el, ix) => el === other[index]));
+    if (Array.isArray(other)) return ((array.length == other.length) && array.every((el, ix) => eq(el, other[ix])));
     if (other == null || other == 0 || other == "") return (array.length == 0);
     return (false);
 }

--- a/satriani/satriani.interpreter.js
+++ b/satriani/satriani.interpreter.js
@@ -21,23 +21,21 @@ Environment.prototype = {
         return (name in this.vars);
     },
 
-    lookup: function (name, index, force_array) {
-        if (name in this.vars) {
-            let variable = this.vars[name];
-            if (Array.isArray(variable)) {
-                if (typeof (index) == 'undefined' || index == null) {
-                    if (force_array || this.FORCE_ARRAY_FLAG) {
-                        this.FORCE_ARRAY_FLAG = false;
-                        return variable;
-                    }
-                    return (variable.length);
-                }
-                return variable[index];
-            }
-            if (typeof (variable) == 'string' && typeof (index) == 'number') return (variable[index]);
-            return variable;
+    lookup: function (name, index) {
+        if (name in this.vars == false) {
+            throw new Error("Undefined variable " + name);
         }
-        throw new Error("Undefined variable " + name);
+        let variable = this.vars[name];
+        if (Array.isArray(variable)) {
+            if (typeof (index) == 'undefined' || index == null) {
+                return variable;
+            }
+            return variable[index];
+        }
+        if (typeof (variable) == 'string' && typeof (index) == 'number') {
+            return (variable[index]);
+        }
+        return variable;
     },
 
     assign: function (name, value, index, local) {
@@ -64,6 +62,13 @@ Environment.prototype = {
     pronoun_alias: null,
 }
 
+function toScalar(value) {
+    if (Array.isArray(value)) {
+        return value.length;
+    }
+    return value;
+}
+
 function evaluate(tree, env) {
     if (tree == MYSTERIOUS || typeof (tree) == 'undefined') return undefined;
     if (tree == null) return null;
@@ -83,7 +88,7 @@ function evaluate(tree, env) {
                 }
                 return result;
             case "conditional":
-                if (evaluate(expr.condition, env)) {
+                if (toScalar(evaluate(expr.condition, env))) {
                     return evaluate(expr.consequent, env);
                 } else if (expr.alternate) {
                     return evaluate(expr.alternate, env);
@@ -100,7 +105,7 @@ function evaluate(tree, env) {
             case "constant":
                 return (expr);
             case "output":
-                let printable = evaluate(expr, env); 2
+                let printable = toScalar(evaluate(expr, env));
                 if (typeof (printable) == 'undefined') printable = "mysterious";
                 env.output(printable);
                 return;
@@ -143,7 +148,7 @@ function evaluate(tree, env) {
                         return;
                 }
             case "while_loop":
-                while_outer: while (evaluate(expr.condition, env)) {
+                while_outer: while (toScalar(evaluate(expr.condition, env))) {
                     let result = evaluate(expr.consequent, env);
                     if (result) switch (result.action) {
                         case 'continue':
@@ -156,7 +161,7 @@ function evaluate(tree, env) {
                 }
                 return;
             case "until_loop":
-                until_outer: while (!evaluate(expr.condition, env)) {
+                until_outer: while (!toScalar(evaluate(expr.condition, env))) {
                     let result = evaluate(expr.consequent, env);
                     if (result) switch (result.action) {
                         case 'continue':
@@ -169,8 +174,8 @@ function evaluate(tree, env) {
                 }
                 return;
             case "comparison":
-                let lhs = evaluate(expr.lhs, env);
-                let rhs = evaluate(expr.rhs, env);
+                let lhs = toScalar(evaluate(expr.lhs, env));
+                let rhs = toScalar(evaluate(expr.rhs, env));
                 switch (expr.comparator) {
                     case "eq":
                         return eq(lhs, rhs);
@@ -188,14 +193,13 @@ function evaluate(tree, env) {
                         throw new Error(`Unknown comparison operator ${expr.comparator}`);
                 }
             case "not":
-                return (!evaluate(expr.expression, env));
+                return (!toScalar(evaluate(expr.expression, env)));
             case "function":
                 env.assign(expr.name, make_lambda(expr, env));
                 return;
             case "call":
                 let func = env.lookup(expr.name);
                 let func_result = func.apply(null, expr.args.map(arg => {
-                    env.FORCE_ARRAY_FLAG = true;
                     let value =  evaluate(arg, env);
                     // If the arg is an array, we shallow-copy it when passing it to a function call
                     return (value && value.map ? value.map(e => e) : value);                
@@ -221,12 +225,9 @@ function mutation(expr, env) {
         case "cast":
             if (typeof (source) == 'string') return parseInt(source, modifier);
             if (typeof (source) == 'number') return String.fromCharCode(source);
+            if (Array.isArray(source)) return String.fromCharCode(toScalar(source));
             throw new Error(`I don't know how to cast ${source}`);
         case "join":
-            // This is a nasty hack but it avoids having to extend the entire
-            // parser with a special additional parameter.
-            env.FORCE_ARRAY_FLAG = true;
-            source = evaluate(expr.source, env);
             if (Array.isArray(source)) {
                 let joiner = (typeof (modifier) == 'undefined' || modifier == null) ? '' : modifier;
                 return source.join(joiner);
@@ -296,7 +297,7 @@ function enlist(expr, env) {
 
 function delist(expr, env) {
     let name = env.dealias(expr);
-    let source = env.lookup(name, null, "FIST")
+    let source = env.lookup(name, null)
     let result = (source.shift && source.shift());
     return result;
 }
@@ -393,9 +394,9 @@ function make_lambda(expr, env) {
 
 function binary(b, env) {
     switch (b.op) {
-        case "and": return (evaluate(b.lhs, env) && evaluate(b.rhs, env));
-        case "nor": return (!evaluate(b.lhs, env) && !evaluate(b.rhs, env));
-        case "or": return (evaluate(b.lhs, env) || evaluate(b.rhs, env));
+        case "and": return (toScalar(evaluate(b.lhs, env)) && toScalar(evaluate(b.rhs, env)));
+        case "nor": return (!toScalar(evaluate(b.lhs, env)) && !toScalar(evaluate(b.rhs, env)));
+        case "or": return (toScalar(evaluate(b.lhs, env)) || toScalar(evaluate(b.rhs, env)));
         case '+': return add(b.lhs, b.rhs, env);
         case '-': return subtract(b.lhs, b.rhs, env);
         case '/': return divide(b.lhs, b.rhs, env);
@@ -404,21 +405,21 @@ function binary(b, env) {
 }
 
 function add(lhs, rhs, env) {
-    return (rhs.reduce ? rhs : [rhs]).reduce((acc, val) => acc += demystify(val, env), demystify(lhs, env));
+    return (rhs.reduce ? rhs : [rhs]).reduce((acc, val) => acc += toScalar(demystify(val, env)), toScalar(demystify(lhs, env)));
 }
 
 function subtract(lhs, rhs, env) {
-    return (rhs.reduce ? rhs : [rhs]).reduce((acc, val) => acc -= evaluate(val, env), evaluate(lhs, env));
+    return (rhs.reduce ? rhs : [rhs]).reduce((acc, val) => acc -= toScalar(evaluate(val, env)), toScalar(evaluate(lhs, env)));
 }
 
 function divide(lhs, rhs, env) {
-    return (rhs.reduce ? rhs : [rhs]).reduce((acc, val) => acc /= evaluate(val, env), evaluate(lhs, env));
+    return (rhs.reduce ? rhs : [rhs]).reduce((acc, val) => acc /= toScalar(evaluate(val, env)), toScalar(evaluate(lhs, env)));
 }
 
 function multiply(lhs, rhs, env) {
     return (rhs.reduce ? rhs : [rhs])
-        .map(expr => evaluate(expr, env))
-        .reduce(multiply_reduce, evaluate(lhs, env));
+        .map(expr => toScalar(evaluate(expr, env)))
+        .reduce(multiply_reduce, toScalar(evaluate(lhs, env)));
 }
 
 function multiply_reduce(acc, val, idx, src) {

--- a/spec.md
+++ b/spec.md
@@ -554,7 +554,7 @@ The higher, the tighter the binding. This is the precedence we generally expect 
 
 #### Binary Comparison
 
-Equality comparisons (`is`, `ain't`, `is not`) are allowed between types if they are the same type or they can be compared by the rules below. Objects are checked by reference equality; all other types are checked by value equality.
+Equality comparisons (`is`, `ain't`, `is not`) are allowed between types if they are the same type or they can be compared by the rules below. Two arrays are equal if their elements are equal.
 
 Ordering comparisons (`is higher than`, `is lower than`, `is as high as`, and `is as low as`) are only allowed if the operands are both Numbers or both Strings or they are converted to such an arrangement according to the rules below. Numbers are compared as expected. Strings are compared lexicographically.
 

--- a/tests/fixtures/arrays/array_functions.rock
+++ b/tests/fixtures/arrays/array_functions.rock
@@ -1,4 +1,20 @@
-Function takes the array
+Shout "function that does nothing"
+
+The void takes something
+Give back nothing
+
+Rock a list with nothing
+Shout a list
+Shout a list at 0
+Let me be the void taking nothing
+Shout a list
+Shout a list at 0
+
+Whisper empty
+
+Shout "function that multiplies elements in an array"
+
+Multiplier takes the array
 The product is 1
 Until the array is nothing
 Roll the array into the variable
@@ -7,8 +23,25 @@ Let the product be the product of the variable
 
 Give back the product
 
-Rock the list with 3,4,5,6,6,8,9,10
-Let the answer be function taking the list
-Shout the answer (should be 120)
+Rock the list with 3,4,5,6,7,8,9,10
+Let the answer be multiplier taking the list
+Shout the answer
+Shout the list
 
-Shout the list (should be 5)
+Whisper empty
+
+Say "function that returns an array"
+
+Rock collection
+Shout collection
+Shout collection at 0
+
+Append takes the array and the arg
+Rock the array with the arg
+Give back the array
+
+Let expansion be append taking collection, "hello"
+Shout collection
+Shout collection at 0
+Shout expansion
+Shout expansion at 0

--- a/tests/fixtures/arrays/array_functions.rock.out
+++ b/tests/fixtures/arrays/array_functions.rock.out
@@ -1,10 +1,25 @@
+function that does nothing
+1
+null
+1
+null
+
+function that multiplies elements in an array
 3
 4
 5
 6
-6
+7
 8
 9
 10
-1555200
+1814400
 8
+
+function that returns an array
+0
+mysterious
+0
+mysterious
+1
+hello

--- a/tests/fixtures/equality/arrays.rock
+++ b/tests/fixtures/equality/arrays.rock
@@ -1,0 +1,33 @@
+rock first with 0, 1, 2
+rock second with 3, 4, 5
+
+if first ain't second
+say "arrays of the same length but different contents are not equal"
+
+ArrayCopy takes source
+rock dest
+let i be 0
+let len be source + 0
+while i is less than len
+let dest at i be source at i
+build i up
+
+return dest
+
+let First Copy be ArrayCopy taking first
+if First Copy is first
+say "element-wise-copied arrays are equal"
+
+let Second Copy be second
+if Second Copy is second
+say "assignment-copied arrays are equal"
+
+rock First Nested with first, second
+rock Second Nested with first, second
+if First Nested is Second Nested
+say "nested arrays with the same contents are equal"
+
+rock Third Nested with first, second
+rock Fourth Nested with second, first
+if Third Nested ain't Fourth Nested
+say "nested arrays with different contents are not equal"

--- a/tests/fixtures/equality/arrays.rock.out
+++ b/tests/fixtures/equality/arrays.rock.out
@@ -1,0 +1,5 @@
+arrays of the same length but different contents are not equal
+element-wise-copied arrays are equal
+assignment-copied arrays are equal
+nested arrays with the same contents are equal
+nested arrays with different contents are not equal


### PR DESCRIPTION
When an array is used in a scalar context, use its length at that time rather than trying to force `env.lookup` to return its length instead of its contents.

This avoids a bug where calling a function caused the next array usage to return the array contents rather than its length. It also allows code to use arrays returned by functions.
