### PR TITLE
Remove unused rule `primary_or_error`

### DIFF
--- a/Starship/Rockstar.Engine/rockstar.peg
+++ b/Starship/Rockstar.Engine/rockstar.peg
@@ -103,9 +103,6 @@ variable_list <IEnumerable<Variable>>
 	= head:variable _VLS_ tail:variable_list { head.Concat(tail) }
 	/ arg:variable_or_error { new List<Variable> { arg } }
 
-primary_or_error <Expression>
-	= p:(primary / #error{ "expected primary expression" }) { p }
-
 primary_list <IEnumerable<Expression>>
 	= head:primary _XLS_ tail:primary_list { head.Concat(tail) }
 	/ head:primary _XLS_ tail:primary { new List<Expression> { head, tail } }


### PR DESCRIPTION
Compiling Rockstar has been generating an "unused rule" warning for a while now. This commit removes that rule because it is indeed never used.

![image](https://github.com/user-attachments/assets/7b1393a8-9302-40b2-a763-e0aa52e440b2)